### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,15 @@ install:
   # we can let conda do dependency resolution when there are conda packages for
   # the various QIIME 2 projects. Until then, avoid installing heavyweight
   # dependencies via pip.
-  - conda create --yes -n test-env -c biocore python=$PYTHON_VERSION scikit-bio jupyter click nose flake8 scikit-learn
+  - conda create --yes -n test-env -c biocore python=$PYTHON_VERSION scikit-bio jupyter click nose scikit-learn
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip
   - pip install https://github.com/qiime2/q2-types/archive/master.zip
+  - pip install flake8
   - pip install .
-  - 'echo "backend      : Agg" > matplotlibrc'
+  - 'echo "backend: Agg" > matplotlibrc'
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
-  - flake8 q2_feature_classifier setup.py
+  - flake8
+  - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, BenKaehler
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of q2-feature-classifier nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2_feature_classifier/__init__.py
+++ b/q2_feature_classifier/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,7 +9,7 @@
 import importlib
 import pkg_resources
 
-__version__ = pkg_resources.require('q2_feature_classifier')[0].version
+__version__ = pkg_resources.get_distribution('q2-feature-classifier').version
 
 
 importlib.import_module('q2_feature_classifier._classifier')

--- a/q2_feature_classifier/_classifier.py
+++ b/q2_feature_classifier/_classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -12,9 +12,10 @@ import inspect
 import copy
 
 import pandas as pd
-from qiime.plugin import Int, Str, Float, Bool
-from q2_types import (FeatureData, Taxonomy, Sequence, PairedEndSequence,
-                      DNAIterator, PairedDNAIterator)
+from qiime2.plugin import Int, Str, Float, Bool
+from q2_types.feature_data import (FeatureData, Taxonomy, Sequence,
+                                   PairedEndSequence, DNAIterator,
+                                   PairedDNAIterator)
 from sklearn.pipeline import Pipeline
 
 from ._skl import fit_pipeline, predict, _specific_fitters
@@ -48,8 +49,10 @@ def fit_classifier(reference_reads: DNAIterator,
                             pipeline, **params)
     return {'params': params, 'pipeline': pipeline}
 
+
 _fitter_parameters = {'word_length': Int, 'taxonomy_separator': Str,
                       'taxonomy_depth': Int, 'multioutput': Bool}
+
 
 plugin.methods.register_function(
     function=fit_classifier,
@@ -97,8 +100,10 @@ def classify(reads: DNAIterator, classifier: dict,
     result.index.name = 'Feature ID'
     return result
 
+
 _classify_parameters = {'chunk_size': Int, 'n_jobs': Int, 'pre_dispatch': Str,
                         'confidence': Float}
+
 
 plugin.methods.register_function(
     function=classify,
@@ -210,6 +215,7 @@ def _register_fitter(name, spec):
         description='Create a ' + class_name +
                     ' classifier for paired-end reads'
     )
+
 
 for name, pipeline in _specific_fitters:
     _register_fitter(name, pipeline)

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -1,13 +1,13 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import Int, Str, Choices
-from q2_types import (
+from qiime2.plugin import Int, Str, Choices
+from q2_types.feature_data import (
     FeatureData, PairedEndSequence, Sequence, DNAIterator, PairedDNAIterator)
 import skbio
 
@@ -63,6 +63,7 @@ def extract_paired_end_reads(sequences: DNAIterator, read_length: int,
         raise ValueError(method + ' method not supported')
 
     return PairedDNAIterator(result)
+
 
 plugin.methods.register_function(
     function=extract_paired_end_reads,
@@ -131,6 +132,7 @@ def extract_reads(sequences: DNAIterator, read_length: int,
         for single_sequence_tuple in result:
             yield single_sequence_tuple[0]
     return DNAIterator(read_seqs())
+
 
 plugin.methods.register_function(
     function=extract_reads,

--- a/q2_feature_classifier/_gregex.py
+++ b/q2_feature_classifier/_gregex.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_skl.py
+++ b/q2_feature_classifier/_skl.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_taxonomic_classifier.py
+++ b/q2_feature_classifier/_taxonomic_classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,14 +11,14 @@ import tarfile
 import os
 
 from sklearn.externals import joblib
-import qiime.plugin
-import qiime.plugin.model as model
+import qiime2.plugin
+import qiime2.plugin.model as model
 
 from .plugin_setup import plugin
 
 
 # Semantic Types
-TaxonomicClassifier = qiime.plugin.SemanticType('TaxonomicClassifier')
+TaxonomicClassifier = qiime2.plugin.SemanticType('TaxonomicClassifier')
 
 
 # Formats
@@ -89,6 +89,7 @@ def _2(data: dict) -> TaxonomicClassifierDirFmt:
     dirfmt.sklearn_pipeline.write_data(sklearn_pipeline, PickleFormat)
 
     return dirfmt
+
 
 # Registrations
 plugin.register_semantic_types(TaxonomicClassifier)

--- a/q2_feature_classifier/plugin_setup.py
+++ b/q2_feature_classifier/plugin_setup.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import Plugin
+from qiime2.plugin import Plugin
 
 import q2_feature_classifier
 

--- a/q2_feature_classifier/tests/__init__.py
+++ b/q2_feature_classifier/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,7 +9,7 @@
 import tempfile
 import shutil
 
-from qiime.plugin.testing import TestPluginBase
+from qiime2.plugin.testing import TestPluginBase
 
 
 class FeatureClassifierTestPluginBase(TestPluginBase):

--- a/q2_feature_classifier/tests/test_classifier.py
+++ b/q2_feature_classifier/tests/test_classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,8 +8,8 @@
 
 import json
 
-from qiime.sdk import Artifact
-from qiime.plugins import feature_classifier
+from qiime2.sdk import Artifact
+from qiime2.plugins import feature_classifier
 import pandas as pd
 
 from q2_feature_classifier._skl import _specific_fitters

--- a/q2_feature_classifier/tests/test_cutter.py
+++ b/q2_feature_classifier/tests/test_cutter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,9 +8,9 @@
 
 from itertools import zip_longest
 
-from qiime.plugins import feature_classifier
-from qiime.sdk import Artifact
-from q2_types import (
+from qiime2.plugins import feature_classifier
+from qiime2.sdk import Artifact
+from q2_types.feature_data import (
     FeatureData, Sequence, PairedEndSequence, DNAIterator, PairedDNAIterator)
 
 

--- a/q2_feature_classifier/tests/test_taxonomic_classifier.py
+++ b/q2_feature_classifier/tests/test_taxonomic_classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, Ben Kaehler
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,17 +10,18 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-feature-classifier",
-    version='0.0.7.dev0',
+    version='2017.2.0.dev0',
     packages=find_packages(),
-    install_requires=['qiime >= 2.0.6', 'q2-types >= 0.0.6', 'scikit-bio',
-                      'biom-format >= 2.1.5, < 2.2.0', 'scikit-learn'],
+    install_requires=['qiime2 == 2017.2.*', 'q2-types == 2017.2.*',
+                      'scikit-bio', 'biom-format >= 2.1.5, < 2.2.0',
+                      'scikit-learn'],
     author="Ben Kaehler",
     author_email="kaehler@gmail.com",
     description="Functionality for taxonomic classification",
     license='BSD-3-Clause',
-    url="https://github.com/qiime2/q2-feature-classifier",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins':
+        'qiime2.plugins':
         ['q2-feature-classifier=q2_feature_classifier.plugin_setup:plugin']
     }
 )


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.

Standardized LICENSE and copyright headers in source files.