### PR TITLE
reads per batch autotuner

### DIFF
--- a/q2_feature_classifier/tests/test_classifier.py
+++ b/q2_feature_classifier/tests/test_classifier.py
@@ -234,5 +234,13 @@ class ClassifierTests(FeatureClassifierTestPluginBase):
 
     def test_autotune_reads_per_batch_zero_jobs(self):
         with self.assertRaisesRegex(
-                ValueError, "n_jobs == 0 in Parallel has no meaning"):
+                ValueError, "Value other than zero must be specified"):
             _autotune_reads_per_batch(self.seq_path, n_jobs=0)
+
+    def test_autotune_reads_per_batch_ceil(self):
+        self.assertEqual(
+            _autotune_reads_per_batch(self.seq_path, n_jobs=5), 221)
+
+    def test_autotune_reads_per_batch_more_jobs_than_reads(self):
+        self.assertEqual(
+            _autotune_reads_per_batch(self.seq_path, n_jobs=1105), 1)


### PR DESCRIPTION
fixes #90 

This is the solution proposed by @BenKaehler in #90 (if `n_jobs` != 1, set `reads-per-batch` = number of reads / n_jobs), not the solution originally proposed by @ElDeveloper (raise an error suggesting a better setting).

The autotuner is enabled if `reads_per_batch` = 0 (new default), but otherwise users can manually set this value (e.g., to disable the autotuner) so I have not removed this parameter.

The autotuner has a negligible impact on runtime:

![image](https://user-images.githubusercontent.com/1907564/33730728-7fc353cc-db46-11e7-8595-7990a11cb4bd.png)
