### PR TITLE
MAINT: temporarily pin sklearn 0.19.1

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   run:
     - python 3.5*
     - setuptools
-    - scikit-learn >=0.19.1
+    - scikit-learn 0.19.1
     - scikit-bio
     - biom-format >=2.1.5,<2.2.0
     - blast >=2.6.0


### PR DESCRIPTION
scikit-learn 0.20.0 is out, and [breaks our integration tests](https://busywork.qiime2.org/teams/main/pipelines/master-distribution/jobs/integration/builds/10#L5b8c57b7:2280) because the pre-trained classifiers are built using 0.19.1. This change should be considered temporary.