### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_feature_classifier/_blast.py
+++ b/q2_feature_classifier/_blast.py
@@ -15,14 +15,13 @@ from ._consensus_assignment import (_consensus_assignments,
                                     _get_default_unassignable_label)
 
 
-def classify_consensus_blast(query: DNAFASTAFormat,
-                             reference_reads: DNAFASTAFormat,
-                             reference_taxonomy: pd.Series, maxaccepts: int=10,
-                             perc_identity: float=0.8, strand: str='both',
-                             evalue: float=0.001, min_consensus: float=0.51,
-                             unassignable_label: str=
-                             _get_default_unassignable_label(),
-                             ) -> pd.DataFrame:
+def classify_consensus_blast(
+    query: DNAFASTAFormat, reference_reads: DNAFASTAFormat,
+    reference_taxonomy: pd.Series, maxaccepts: int = 10,
+        perc_identity: float = 0.8, strand: str = 'both',
+        evalue: float = 0.001, min_consensus: float = 0.51,
+        unassignable_label: str = _get_default_unassignable_label(),
+        ) -> pd.DataFrame:
     perc_identity = perc_identity * 100
     seqs_fp = str(query)
     ref_fp = str(reference_reads)

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -122,8 +122,8 @@ def _gen_reads(sequences,  f_primer, r_primer, trunc_len, trim_left, identity):
 
 
 def extract_reads(sequences: DNAIterator,  f_primer: str, r_primer: str,
-                  trunc_len: int=0, trim_left: int=0,
-                  identity: float=0.8) -> DNAIterator:
+                  trunc_len: int = 0, trim_left: int = 0,
+                  identity: float = 0.8) -> DNAIterator:
     """Extract the read selected by a primer or primer pair. Only sequences
     which match the primers at greater than the specified identity are returned
 

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -18,12 +18,12 @@ from ._consensus_assignment import (_consensus_assignments,
 def classify_consensus_vsearch(query: DNAFASTAFormat,
                                reference_reads: DNAFASTAFormat,
                                reference_taxonomy: pd.Series,
-                               maxaccepts: int=10,
-                               perc_identity: int=0.8, strand: str='both',
-                               min_consensus: float=0.51,
-                               unassignable_label: str=
+                               maxaccepts: int = 10,
+                               perc_identity: int = 0.8, strand: str = 'both',
+                               min_consensus: float = 0.51,
+                               unassignable_label: str =
                                _get_default_unassignable_label(),
-                               threads: str=1) -> pd.DataFrame:
+                               threads: str = 1) -> pd.DataFrame:
     seqs_fp = str(query)
     ref_fp = str(reference_reads)
     cmd = ['vsearch', '--usearch_global', seqs_fp, '--id', str(perc_identity),

--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -125,7 +125,7 @@ def populate_class_weight(pipeline, class_weight):
 def fit_classifier_sklearn(reference_reads: DNAIterator,
                            reference_taxonomy: pd.Series,
                            classifier_specification: str,
-                           class_weight: biom.Table=None) -> Pipeline:
+                           class_weight: biom.Table = None) -> Pipeline:
     warn_about_sklearn()
     spec = json.loads(classifier_specification)
     pipeline = pipeline_from_spec(spec)
@@ -196,9 +196,9 @@ def _autotune_reads_per_batch(reads, n_jobs):
 
 
 def classify_sklearn(reads: DNAFASTAFormat, classifier: Pipeline,
-                     reads_per_batch: int=0, n_jobs: int=1,
-                     pre_dispatch: str='2*n_jobs', confidence: float=0.7,
-                     read_orientation: str=None
+                     reads_per_batch: int = 0, n_jobs: int = 1,
+                     pre_dispatch: str = '2*n_jobs', confidence: float = 0.7,
+                     read_orientation: str = None
                      ) -> pd.DataFrame:
     # autotune reads per batch
     if reads_per_batch == 0:
@@ -301,7 +301,7 @@ def _register_fitter(name, spec):
 
     def generic_fitter(reference_reads: DNAIterator,
                        reference_taxonomy: pd.Series,
-                       class_weight: biom.Table=None, **kwargs) -> Pipeline:
+                       class_weight: biom.Table = None, **kwargs) -> Pipeline:
         warn_about_sklearn()
         for param in kwargs:
             try:

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Numerous minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.