### PR TITLE
ENH: `classify-consensus-vsearch` upgrades, plus hybrid classifier

### DIFF
--- a/q2_feature_classifier/_consensus_assignment.py
+++ b/q2_feature_classifier/_consensus_assignment.py
@@ -40,7 +40,7 @@ def _consensus_assignments(
             consensus = {'': ('', '')}
         result = pd.DataFrame.from_dict(consensus, 'index')
         result.index.name = 'Feature ID'
-        result.columns = ['Taxon', 'Confidence']
+        result.columns = ['Taxon', 'Consensus']
         return result
 
 

--- a/q2_feature_classifier/_consensus_assignment.py
+++ b/q2_feature_classifier/_consensus_assignment.py
@@ -11,6 +11,7 @@ import subprocess
 import pandas as pd
 from os.path import isfile
 from collections import Counter, defaultdict
+import qiime2
 
 
 def _get_default_unassignable_label():
@@ -242,3 +243,9 @@ def _compute_consensus_annotation(annotations, min_consensus,
         consensus_fraction_result = 1.0
 
     return annotation, consensus_fraction_result
+
+
+def _annotate_method(taxa, method):
+    taxa = taxa.view(pd.DataFrame)
+    taxa['method'] = method
+    return qiime2.Artifact.import_data('FeatureData[Taxonomy]', taxa)

--- a/q2_feature_classifier/_skl.py
+++ b/q2_feature_classifier/_skl.py
@@ -38,7 +38,7 @@ def _extract_reads(reads):
 
 
 def predict(reads, pipeline, separator=';', chunk_size=262144, n_jobs=1,
-            pre_dispatch='2*n_jobs', confidence=-1.):
+            pre_dispatch='2*n_jobs', confidence='disable'):
     return (m for c in Parallel(n_jobs=n_jobs, batch_size=1,
                                 pre_dispatch=pre_dispatch)
             (delayed(_predict_chunk)(pipeline, separator, confidence, chunk)
@@ -46,7 +46,7 @@ def predict(reads, pipeline, separator=';', chunk_size=262144, n_jobs=1,
 
 
 def _predict_chunk(pipeline, separator, confidence, chunk):
-    if confidence < 0.:
+    if confidence == 'disable':
         return _predict_chunk_without_conf(pipeline, chunk)
     else:
         return _predict_chunk_with_conf(pipeline, separator, confidence, chunk)

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -36,6 +36,8 @@ def classify_consensus_vsearch(query: DNAFASTAFormat,
                                threads: str = 1) -> pd.DataFrame:
     seqs_fp = str(query)
     ref_fp = str(reference_reads)
+    if maxaccepts == 'all':
+        maxaccepts = 0
     cmd = ['vsearch', '--usearch_global', seqs_fp, '--id', str(perc_identity),
            '--query_cov', str(query_cov), '--strand', strand, '--maxaccepts',
            str(maxaccepts), '--maxrejects', '0', '--output_no_hits', '--db',
@@ -143,7 +145,7 @@ parameter_descriptions = {
     'strand': 'Align against reference sequences in forward ("plus") '
               'or both directions ("both").',
     'maxaccepts': 'Maximum number of hits to keep for each query. Set to '
-                  '0 to keep all hits > perc_identity similarity. Must '
+                  '"all" to keep all hits > perc_identity similarity. Must '
                   'be in range [0, infinity].',
     'perc_identity': 'Reject match if percent identity to query is '
                      'lower. Must be in range [0.0, 1.0].',

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -131,7 +131,7 @@ parameters = {'maxaccepts': Int % Range(1, None) | Str % Choices(['all']),
               'strand': Str % Choices(['both', 'plus']),
               'min_consensus': Float % Range(0.5, 1.0, inclusive_end=True,
                                              inclusive_start=False),
-              'threads': Int}
+              'threads': Int % Range(1, None)}
 
 inputs = {'query': FeatureData[Sequence],
           'reference_reads': FeatureData[Sequence],

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -145,15 +145,13 @@ parameter_descriptions = {
     'strand': 'Align against reference sequences in forward ("plus") '
               'or both directions ("both").',
     'maxaccepts': 'Maximum number of hits to keep for each query. Set to '
-                  '"all" to keep all hits > perc_identity similarity. Must '
-                  'be in range [0, infinity].',
+                  '"all" to keep all hits > perc_identity similarity.',
     'perc_identity': 'Reject match if percent identity to query is '
-                     'lower. Must be in range [0.0, 1.0].',
+                     'lower.',
     'query_cov': 'Reject match if query alignment coverage per high-'
-                 'scoring pair is lower. Must be in range [0.0, 1.0].',
+                 'scoring pair is lower.',
     'min_consensus': 'Minimum fraction of assignments must match top '
-                     'hit to be accepted as consensus assignment. Must '
-                     'be in range (0.5, 1.0].',
+                     'hit to be accepted as consensus assignment.',
     'threads': 'Number of threads to use for job parallelization.'}
 
 outputs = [('classification', FeatureData[Taxonomy])]
@@ -221,8 +219,8 @@ plugin.pipelines.register_function(
                             'orientation based on the confidence estimates '
                             'for the first 100 reads.',
         'reads_per_batch': 'Number of reads to process in each batch for '
-                           'sklearn classification. If 0, this parameter is '
-                           'autoscaled to min(number of query sequences / '
+                           'sklearn classification. If "auto", this parameter '
+                           'is autoscaled to min(number of query sequences / '
                            'threads, 20000).',
         'prefilter': 'Toggle positive filter of query sequences on or off.'
     },

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -107,7 +107,7 @@ def classify_hybrid_vsearch_sklearn(ctx,
         taxa['method'] = method
         return qiime2.Artifact.import_data('FeatureData[Taxonomy]', taxa)
     taxa1 = _annotate_method(taxa1, 'VSEARCH')
-    taxa1 = _annotate_method(taxa2, 'sklearn')
+    taxa2 = _annotate_method(taxa2, 'sklearn')
 
     # merge into one big happy result
     taxa, = merge(data=[taxa2, taxa1])

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -213,7 +213,10 @@ plugin.pipelines.register_function(
                       'sklearn classifier. Provide -1 to disable confidence '
                       'calculation, or 0 to calculate confidence but not '
                       'apply it to limit the taxonomic depth of the '
-                      'assignments.',
+                      'assignments. Note that confidence scores should be '
+                      'interpreted differently depending on the sklearn '
+                      'classifier that is used for classification. Refer to: '
+                      'https://scikit-learn.org/stable/documentation.html',
         'read_orientation': 'Direction of reads with respect to reference '
                             'sequences in pre-trained sklearn classifier. '
                             'same will cause reads to be classified unchanged'
@@ -225,7 +228,7 @@ plugin.pipelines.register_function(
         'reads_per_batch': 'Number of reads to process in each batch for '
                            'sklearn classification. If 0, this parameter is '
                            'autoscaled to min( number of query sequences / '
-                           'n_jobs, 20000).',
+                           'threads, 20000).',
         'prefilter': 'Toggle positive filter of query sequences on or off.'
     },
     output_descriptions=output_descriptions,

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -18,6 +18,7 @@ from ._consensus_assignment import (_consensus_assignments, _run_command,
                                     _get_default_unassignable_label,
                                     _annotate_method)
 from ._taxonomic_classifier import TaxonomicClassifier
+from .classifier import _classify_parameters
 
 
 def classify_consensus_vsearch(query: DNAFASTAFormat,
@@ -198,10 +199,9 @@ plugin.pipelines.register_function(
     function=classify_hybrid_vsearch_sklearn,
     inputs={**inputs, 'classifier': TaxonomicClassifier},
     parameters={**parameters,
-                'reads_per_batch': Int % Range(0, None),
-                'confidence': Float,
-                'read_orientation': Str % Choices(
-                    ['same', 'reverse-complement']),
+                'reads_per_batch': _classify_parameters['reads_per_batch'],
+                'confidence': _classify_parameters['confidence'],
+                'read_orientation': _classify_parameters['read_orientation'],
                 'prefilter': Bool},
     outputs=outputs,
     input_descriptions={**input_descriptions,
@@ -209,22 +209,15 @@ plugin.pipelines.register_function(
                                       'classifier for classifying the reads.'},
     parameter_descriptions={
         **parameter_descriptions,
-        'confidence': 'Confidence threshold for limiting taxonomic depth with '
-                      'sklearn classifier. Provide -1 to disable confidence '
-                      'calculation, or 0 to calculate confidence but not '
-                      'apply it to limit the taxonomic depth of the '
-                      'assignments. Note that confidence scores should be '
-                      'interpreted differently depending on the sklearn '
-                      'classifier that is used for classification. Refer to: '
-                      'https://scikit-learn.org/stable/documentation.html',
+        'confidence': _parameter_descriptions['confidence'],
         'read_orientation': 'Direction of reads with respect to reference '
                             'sequences in pre-trained sklearn classifier. '
                             'same will cause reads to be classified unchanged'
                             '; reverse-complement will cause reads to be '
                             'reversed and complemented prior to '
-                            'classification. Default is to autodetect based '
-                            'on the confidence estimates for the first 100 '
-                            'reads.',
+                            'classification. "auto" will autodetect '
+                            'orientation based on the confidence estimates '
+                            'for the first 100 reads.',
         'reads_per_batch': 'Number of reads to process in each batch for '
                            'sklearn classification. If 0, this parameter is '
                            'autoscaled to min( number of query sequences / '

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -18,7 +18,7 @@ from ._consensus_assignment import (_consensus_assignments, _run_command,
                                     _get_default_unassignable_label,
                                     _annotate_method)
 from ._taxonomic_classifier import TaxonomicClassifier
-from .classifier import _classify_parameters
+from .classifier import _classify_parameters, _parameter_descriptions
 
 
 def classify_consensus_vsearch(query: DNAFASTAFormat,
@@ -226,7 +226,8 @@ plugin.pipelines.register_function(
     },
     output_descriptions=output_descriptions,
     name='ALPHA Hybrid classifier: VSEARCH exact match + sklearn classifier',
-    description=('NOTE: THIS PIPELINE IS AN ALPHA RELEASE. Please report bugs to https://forum.qiime2.org!\n'
+    description=('NOTE: THIS PIPELINE IS AN ALPHA RELEASE. Please report bugs '
+                 'to https://forum.qiime2.org!\n'
                  'Assign taxonomy to query sequences using hybrid classifier. '
                  'First performs rough positive filter to remove artifact and '
                  'low-coverage sequences (use "prefilter" parameter to toggle '

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -6,13 +6,17 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import tempfile
 import pandas as pd
+import qiime2
+
 from q2_types.feature_data import (
     FeatureData, Taxonomy, Sequence, DNAFASTAFormat)
 from .plugin_setup import plugin, citations
-from qiime2.plugin import Int, Str, Float, Choices, Range
-from ._consensus_assignment import (_consensus_assignments,
+from qiime2.plugin import Int, Str, Float, Choices, Range, Bool
+from ._consensus_assignment import (_consensus_assignments, _run_command,
                                     _get_default_unassignable_label)
+from ._taxonomic_classifier import TaxonomicClassifier
 
 
 def classify_consensus_vsearch(query: DNAFASTAFormat,
@@ -25,53 +29,147 @@ def classify_consensus_vsearch(query: DNAFASTAFormat,
                                min_consensus: float = 0.51,
                                unassignable_label: str =
                                _get_default_unassignable_label(),
+                               search_exact: bool = False,
+                               top_hits_only: bool = False,
                                threads: str = 1) -> pd.DataFrame:
     seqs_fp = str(query)
     ref_fp = str(reference_reads)
     cmd = ['vsearch', '--usearch_global', seqs_fp, '--id', str(perc_identity),
            '--query_cov', str(query_cov), '--strand', strand, '--maxaccepts',
            str(maxaccepts), '--maxrejects', '0', '--output_no_hits', '--db',
-           ref_fp, '--threads', str(threads), '--blast6out']
+           ref_fp, '--threads', str(threads)]
+    if search_exact:
+        cmd[1] = '--search_exact'
+    if top_hits_only:
+        cmd.append('--top_hits_only')
+    cmd.append('--blast6out')
     consensus = _consensus_assignments(
         cmd, reference_taxonomy, min_consensus=min_consensus,
         unassignable_label=unassignable_label)
     return consensus
 
 
+def classify_hybrid_vsearch_sklearn(ctx,
+                                    query,
+                                    reference_reads,
+                                    reference_taxonomy,
+                                    classifier,
+                                    maxaccepts=10,
+                                    perc_identity=0.5,
+                                    query_cov=0.8,
+                                    strand='both',
+                                    min_consensus=0.51,
+                                    reads_per_batch=0,
+                                    confidence=0.7,
+                                    read_orientation=None,
+                                    threads=1,
+                                    prefilter=True):
+    exclude = ctx.get_action('quality_control', 'exclude_seqs')
+    ccv = ctx.get_action('feature_classifier', 'classify_consensus_vsearch')
+    cs = ctx.get_action('feature_classifier', 'classify_sklearn')
+    filter_seqs = ctx.get_action('taxa', 'filter_seqs')
+    merge = ctx.get_action('feature_table', 'merge_taxa')
+
+    # randomly subsample reference sequences for rough positive filter
+    if prefilter:
+        ref = str(reference_reads.view(DNAFASTAFormat))
+        with tempfile.NamedTemporaryFile() as output:
+            cmd = ['vsearch', '--fastx_subsample', ref,
+                   '--sample_size', '100', '--fastaout', output.name]
+            _run_command(cmd)
+            sparse_reference = qiime2.Artifact.import_data(
+                'FeatureData[Sequence]', output.name)
+
+            # perform rough positive filter on query sequences
+            query, misses, = exclude(
+                query_sequences=query, reference_sequences=sparse_reference,
+                method='vsearch', perc_identity=perc_identity,
+                perc_query_aligned=query_cov, threads=threads)
+
+    # find exact matches, perform LCA consensus classification
+    taxa1, = ccv(query=query, reference_reads=reference_reads,
+                 reference_taxonomy=reference_taxonomy, maxaccepts=maxaccepts,
+                 strand=strand, min_consensus=min_consensus,
+                 search_exact=True, threads=threads)
+
+    # filter out unassigned seqs
+    query, = filter_seqs(sequences=query, taxonomy=taxa1,
+                         exclude=_get_default_unassignable_label())
+
+    # classify with sklearn classifier
+    taxa2, = cs(reads=query, classifier=classifier,
+                reads_per_batch=reads_per_batch, n_jobs=threads,
+                confidence=confidence, read_orientation=read_orientation)
+
+    # merge into one big happy result
+    taxa, = merge(data=[taxa1, taxa2])
+    return taxa
+
+
+output_descriptions = {
+    'classification': 'The resulting taxonomy classifications.'}
+
+parameters = {'maxaccepts': Int % Range(0, None),
+              'perc_identity': Float % Range(0.0, 1.0, inclusive_end=True),
+              'query_cov': Float % Range(0.0, 1.0, inclusive_end=True),
+              'strand': Str % Choices(['both', 'plus']),
+              'min_consensus': Float % Range(0.5, 1.0, inclusive_end=True,
+                                             inclusive_start=False),
+              'threads': Int}
+
+inputs = {'query': FeatureData[Sequence],
+          'reference_reads': FeatureData[Sequence],
+          'reference_taxonomy': FeatureData[Taxonomy]}
+
+input_descriptions = {'query': 'Sequences to classify taxonomically.',
+                      'reference_reads': 'reference sequences.',
+                      'reference_taxonomy': 'reference taxonomy labels.'}
+
+parameter_descriptions = {
+    'strand': 'Align against reference sequences in forward ("plus") '
+              'or both directions ("both").',
+    'maxaccepts': 'Maximum number of hits to keep for each query. Set to '
+                  '0 to keep all hits > perc_identity similarity. Must '
+                  'be in range [0, infinity].',
+    'perc_identity': 'Reject match if percent identity to query is '
+                     'lower. Must be in range [0.0, 1.0].',
+    'query_cov': 'Reject match if query alignment coverage per high-'
+                 'scoring pair is lower. Must be in range [0.0, 1.0].',
+    'min_consensus': 'Minimum fraction of assignments must match top '
+                     'hit to be accepted as consensus assignment. Must '
+                     'be in range (0.5, 1.0].',
+    'threads': 'Number of threads to use for job parallelization.'}
+
+outputs = [('classification', FeatureData[Taxonomy])]
+
+
 plugin.methods.register_function(
     function=classify_consensus_vsearch,
-    inputs={'query': FeatureData[Sequence],
-            'reference_reads': FeatureData[Sequence],
-            'reference_taxonomy': FeatureData[Taxonomy]},
-    parameters={'maxaccepts': Int % Range(0, None),
-                'perc_identity': Float % Range(0.0, 1.0, inclusive_end=True),
-                'query_cov': Float % Range(0.0, 1.0, inclusive_end=True),
-                'strand': Str % Choices(['both', 'plus']),
-                'min_consensus': Float % Range(0.5, 1.0, inclusive_end=True,
-                                               inclusive_start=False),
+    inputs=inputs,
+    parameters={**parameters,
                 'unassignable_label': Str,
-                'threads': Int},
-    outputs=[('classification', FeatureData[Taxonomy])],
-    input_descriptions={'query': 'Sequences to classify taxonomically.',
-                        'reference_reads': 'reference sequences.',
-                        'reference_taxonomy': 'reference taxonomy labels.'},
+                'search_exact': Bool,
+                'top_hits_only': Bool},
+    outputs=outputs,
+    input_descriptions=input_descriptions,
     parameter_descriptions={
-        'strand': ('Align against reference sequences in forward ("plus") '
-                   'or both directions ("both").'),
-        'maxaccepts': ('Maximum number of hits to keep for each query. Set to '
-                       '0 to keep all hits > perc_identity similarity. Must '
-                       'be in range [0, infinity].'),
-        'perc_identity': ('Reject match if percent identity to query is '
-                          'lower. Must be in range [0.0, 1.0].'),
-        'query_cov': 'Reject match if query alignment coverage per high-'
-                     'scoring pair is lower. Must be in range [0.0, 1.0].',
-        'min_consensus': ('Minimum fraction of assignments must match top '
-                          'hit to be accepted as consensus assignment. Must '
-                          'be in range (0.5, 1.0].')
+        **parameter_descriptions,
+        'search_exact': 'Search for exact full-length matches to the query '
+                        'sequences. Only 100% exact matches are reported and '
+                        'this command is much faster than the default. If '
+                        'True, the perc_identity and query_cov settings are '
+                        'ignored. Note: query and reference reads must be '
+                        'trimmed to the exact same DNA locus (e.g., primer '
+                        'site) because only exact matches will be reported.',
+        'top_hits_only': 'Only the top hits between the query and reference '
+                         'sequence sets are reported. For each query, the top '
+                         'hit is the one presenting the highest percentage of '
+                         'identity. Multiple equally scored top hits will be '
+                         'used for consensus taxonomic assignment if '
+                         'maxaccepts is greater than 1.',
     },
-    output_descriptions={'classification': 'The resulting taxonomy '
-                         'classifications.'},
-    name='VSEARCH consensus taxonomy classifier',
+    output_descriptions=output_descriptions,
+    name='VSEARCH-based consensus taxonomy classifier',
     description=('Assign taxonomy to query sequences using VSEARCH. Performs '
                  'VSEARCH global alignment between query and reference_reads, '
                  'then assigns consensus taxonomy to each query sequence from '
@@ -80,4 +178,55 @@ plugin.methods.register_function(
                  'this method searches the entire reference database before '
                  'choosing the top N hits, not the first N hits.'),
     citations=[citations['rognes2016vsearch']]
+)
+
+
+plugin.pipelines.register_function(
+    function=classify_hybrid_vsearch_sklearn,
+    inputs={**inputs, 'classifier': TaxonomicClassifier},
+    parameters={**parameters,
+                'reads_per_batch': Int % Range(0, None),
+                'confidence': Float,
+                'read_orientation': Str % Choices(
+                    ['same', 'reverse-complement']),
+                'prefilter': Bool},
+    outputs=outputs,
+    input_descriptions={**input_descriptions,
+                        'classifier': 'Pre-trained sklearn taxonomic '
+                                      'classifier for classifying the reads.'},
+    parameter_descriptions={
+        **parameter_descriptions,
+        'confidence': 'Confidence threshold for limiting taxonomic depth with '
+                      'sklearn classifier. Provide -1 to disable confidence '
+                      'calculation, or 0 to calculate confidence but not '
+                      'apply it to limit the taxonomic depth of the '
+                      'assignments.',
+        'read_orientation': 'Direction of reads with respect to reference '
+                            'sequences in pre-trained sklearn classifier. '
+                            'same will cause reads to be classified unchanged'
+                            '; reverse-complement will cause reads to be '
+                            'reversed and complemented prior to '
+                            'classification. Default is to autodetect based '
+                            'on the confidence estimates for the first 100 '
+                            'reads.',
+        'reads_per_batch': 'Number of reads to process in each batch for '
+                           'sklearn classification. If 0, this parameter is '
+                           'autoscaled to min( number of query sequences / '
+                           'n_jobs, 20000).',
+        'prefilter': 'Toggle positive filter of query sequences on or off.'
+    },
+    output_descriptions=output_descriptions,
+    name='ALPHA Hybrid classifier: VSEARCH exact match + sklearn classifier',
+    description=('NOTE: ALPHA RELEASE. Please report bugs to the q2-forum!\n'
+                 'Assign taxonomy to query sequences using hybrid classifier. '
+                 'First performs rough positive filter to remove artifact and '
+                 'low-coverage sequences (use "prefilter" parameter to toggle '
+                 'this step on or off). Second, performs VSEARCH exact match '
+                 'between query and reference_reads to find exact matches, '
+                 'followed by least common ancestor consensus taxonomy '
+                 'assignment from among maxaccepts top hits, min_consensus of '
+                 'which share that taxonomic assignment. Query sequences '
+                 'without an exact match are then classified with a pre-'
+                 'trained sklearn taxonomy classifier to predict the most '
+                 'likely taxonomic lineage.'),
 )

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -65,7 +65,7 @@ def classify_hybrid_vsearch_sklearn(ctx,
                                     min_consensus=0.51,
                                     reads_per_batch=0,
                                     confidence=0.7,
-                                    read_orientation=None,
+                                    read_orientation='auto',
                                     threads=1,
                                     prefilter=True):
     exclude = ctx.get_action('quality_control', 'exclude_seqs')

--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -244,7 +244,7 @@ _parameter_descriptions = {
                         'and complemented prior to classification. '
                         '"auto" will autodetect orientation based on the '
                         'confidence estimates for the first 100 reads.',
-    'reads_per_batch': 'Number of reads to process in each batch. If 0, '
+    'reads_per_batch': 'Number of reads to process in each batch. If "auto", '
                        'this parameter is autoscaled to '
                        'min( number of query sequences / n_jobs, 20000).',
     'n_jobs': 'The maximum number of concurrently worker processes. If -1 '

--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -268,7 +268,7 @@ plugin.methods.register_function(
         'reads': 'The feature data to be classified.',
         'classifier': 'The taxonomic classifier for classifying the reads.'
     },
-    parameter_descriptions={_parameter_descriptions},
+    parameter_descriptions={**_parameter_descriptions},
     citations=[citations['pedregosa2011scikit']]
 )
 

--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -200,7 +200,7 @@ def _autotune_reads_per_batch(reads, n_jobs):
 def classify_sklearn(reads: DNAFASTAFormat, classifier: Pipeline,
                      reads_per_batch: int = 0, n_jobs: int = 1,
                      pre_dispatch: str = '2*n_jobs', confidence: float = 0.7,
-                     read_orientation: str = None
+                     read_orientation: str = 'auto'
                      ) -> pd.DataFrame:
     # autotune reads per batch
     if reads_per_batch == 0:
@@ -226,9 +226,35 @@ _classify_parameters = {
     'reads_per_batch': Int % Range(0, None),
     'n_jobs': Int,
     'pre_dispatch': Str,
-    'confidence': Float,
-    'read_orientation': Str % Choices(['same', 'reverse-complement'])}
+    'confidence': Float % Range(
+        0, 1, inclusive_start=True, inclusive_end=True) | Str % Choices(
+            ['disable']),
+    'read_orientation': Str % Choices(['same', 'reverse-complement', 'auto'])}
 
+_parameter_descriptions = {
+    'confidence': 'Confidence threshold for limiting '
+                  'taxonomic depth. Set to "disable" to disable '
+                  'confidence calculation, or 0 to calculate '
+                  'confidence but not apply it to limit the '
+                  'taxonomic depth of the assignments.',
+    'read_orientation': 'Direction of reads with '
+                        'respect to reference sequences. same will cause '
+                        'reads to be classified unchanged; reverse-'
+                        'complement will cause reads to be reversed '
+                        'and complemented prior to classification. '
+                        '"auto" will autodetect orientation based on the '
+                        'confidence estimates for the first 100 reads.',
+    'reads_per_batch': 'Number of reads to process in each batch. If 0, '
+                       'this parameter is autoscaled to '
+                       'min( number of query sequences / n_jobs, 20000).',
+    'n_jobs': 'The maximum number of concurrently worker processes. If -1 '
+              'all CPUs are used. If 1 is given, no parallel computing '
+              'code is used at all, which is useful for debugging. For '
+              'n_jobs below -1, (n_cpus + 1 + n_jobs) are used. Thus for '
+              'n_jobs = -2, all CPUs but one are used.',
+    'pre_dispatch': '"all" or expression, as in "3*n_jobs". The number of '
+                    'batches (of tasks) to be pre-dispatched.'
+}
 
 plugin.methods.register_function(
     function=classify_sklearn,
@@ -242,30 +268,7 @@ plugin.methods.register_function(
         'reads': 'The feature data to be classified.',
         'classifier': 'The taxonomic classifier for classifying the reads.'
     },
-    parameter_descriptions={
-        'confidence': 'Confidence threshold for limiting '
-                      'taxonomic depth. Provide -1 to disable '
-                      'confidence calculation, or 0 to calculate '
-                      'confidence but not apply it to limit the '
-                      'taxonomic depth of the assignments.',
-        'read_orientation': 'Direction of reads with '
-                            'respect to reference sequences. same will cause '
-                            'reads to be classified unchanged; reverse-'
-                            'complement will cause reads to be reversed '
-                            'and complemented prior to classification. '
-                            'Default is to autodetect based on the '
-                            'confidence estimates for the first 100 reads.',
-        'reads_per_batch': 'Number of reads to process in each batch. If 0, '
-                           'this parameter is autoscaled to '
-                           'min( number of query sequences / n_jobs, 20000).',
-        'n_jobs': 'The maximum number of concurrently worker processes. If -1 '
-                  'all CPUs are used. If 1 is given, no parallel computing '
-                  'code is used at all, which is useful for debugging. For '
-                  'n_jobs below -1, (n_cpus + 1 + n_jobs) are used. Thus for '
-                  'n_jobs = -2, all CPUs but one are used.',
-        'pre_dispatch': '"all" or expression, as in "3*n_jobs". The number of '
-                        'batches (of tasks) to be pre-dispatched.'
-    },
+    parameter_descriptions={_parameter_descriptions},
     citations=[citations['pedregosa2011scikit']]
 )
 

--- a/q2_feature_classifier/tests/test_consensus_assignment.py
+++ b/q2_feature_classifier/tests/test_consensus_assignment.py
@@ -12,8 +12,7 @@ from qiime2.sdk import Artifact
 from qiime2.plugins import feature_classifier
 from q2_feature_classifier._skl import _specific_fitters
 from q2_feature_classifier._blast import classify_consensus_blast
-from q2_feature_classifier._vsearch import (
-    classify_consensus_vsearch, classify_hybrid_vsearch_sklearn)
+from q2_feature_classifier._vsearch import classify_consensus_vsearch
 from q2_feature_classifier._consensus_assignment import (
     _compute_consensus_annotation,
     _compute_consensus_annotations,

--- a/q2_feature_classifier/tests/test_consensus_assignment.py
+++ b/q2_feature_classifier/tests/test_consensus_assignment.py
@@ -77,6 +77,7 @@ class ConsensusAssignmentsTests(FeatureClassifierTestPluginBase):
             right += tax[taxon].startswith(res[taxon])
         self.assertGreater(right/len(res), 0.5)
 
+
 class HybridClassiferTests(FeatureClassifierTestPluginBase):
     package = 'q2_feature_classifier.tests'
 


### PR DESCRIPTION
a hybrid beast is born.

The hybrid classifier is really just a pipeline of `classify-consensus-vsearch` + `classify-sklearn` with some extra bells and whistles thrown in.

This PR also contains some awesome enhancements to `classify-consensus-vsearch`, allowing for exact hit matching and top hit selection.

The hybrid classifier works for me but could use some more alpha testing if anyone is interested. Or we can unleash and see what chaos ensues.