### PR TITLE
Check for min length > trunc length before executing

### DIFF
--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -168,10 +168,10 @@ def extract_reads(sequences: DNASequencesDirectoryFormat, f_primer: str,
     q2_types.DNAFASTAFormat
         containing the reads
     """
-    if min_length > trunc_len and trunc_len > 0:
+    if min_length > trunc_len - trim_left and trunc_len > 0:
         raise ValueError('Your minimum length is larger than your truncation '
-                         'length, this will result in all of your sequences '
-                         'being trimmed automatically.')
+                         'length minus your trim, this will result in all of '
+                         'your sequences being trimmed automatically.')
     n_jobs = effective_n_jobs(n_jobs)
     if batch_size == 'auto':
         batch_size = _autotune_reads_per_batch(

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -168,6 +168,10 @@ def extract_reads(sequences: DNASequencesDirectoryFormat, f_primer: str,
     q2_types.DNAFASTAFormat
         containing the reads
     """
+    if min_length > trunc_len and trunc_len > 0:
+        raise ValueError('Your minimum length is larger than your truncation '
+                         'length, this will result in all of your sequences '
+                         'being trimmed automatically.')
     n_jobs = effective_n_jobs(n_jobs)
     if batch_size == 'auto':
         batch_size = _autotune_reads_per_batch(

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -169,11 +169,10 @@ def extract_reads(sequences: DNASequencesDirectoryFormat, f_primer: str,
         containing the reads
     """
     if min_length > trunc_len - trim_left and trunc_len > 0:
-        raise ValueError('Your minimum length is larger than your truncation '
-                         'length minus your trim. This will result in all of '
-                         'your sequences being removed from your dataset. To '
-                         'procees, you must set a minimum length less than '
-                         'your truncation length minus your trim.')
+        raise ValueError('The minimum length setting is greater than the '
+                         'length of the truncated sequences. This will cause '
+                         'all sequences to be removed from the dataset. To '
+                         'proceed, set a min_length ≤ trunc_len - trim_left.')
     n_jobs = effective_n_jobs(n_jobs)
     if batch_size == 'auto':
         batch_size = _autotune_reads_per_batch(

--- a/q2_feature_classifier/tests/test_cutter.py
+++ b/q2_feature_classifier/tests/test_cutter.py
@@ -104,7 +104,7 @@ class CutterTests(FeatureClassifierTestPluginBase):
                 trim_left=4)
 
     def test_extract_reads_fail_min_len_greater_than_trunc_len(self):
-        with self.assertRaisesRegex(ValueError, "minimum length is larger"):
+        with self.assertRaisesRegex(ValueError, "minimum length setting"):
             extract_reads(
                 self.sequences, f_primer=self.f_primer, r_primer=self.r_primer,
                 trunc_len=1)

--- a/q2_feature_classifier/tests/test_cutter.py
+++ b/q2_feature_classifier/tests/test_cutter.py
@@ -98,7 +98,7 @@ class CutterTests(FeatureClassifierTestPluginBase):
                 max_length=1)
 
     def test_extract_reads_fail_trim_entire_read(self):
-        with self.assertRaisesRegex(RuntimeError, "No matches found"):
+        with self.assertRaisesRegex(ValueError, "minimum length is larger"):
             extract_reads(
                 self.sequences, f_primer=self.f_primer, r_primer=self.r_primer,
                 trunc_len=1, trim_left=1)


### PR DESCRIPTION
Closes #119. A ValueError is now raised immediately if `min_length` is greater than `trunc_len` and `trunc_len` is greater than 0.
