### PR TITLE
MAINT: Update copyright header to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2016-2019, QIIME 2 development team.
+Copyright (c) 2016-2020, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/q2_feature_classifier/__init__.py
+++ b/q2_feature_classifier/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_blast.py
+++ b/q2_feature_classifier/_blast.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_consensus_assignment.py
+++ b/q2_feature_classifier/_consensus_assignment.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_skl.py
+++ b/q2_feature_classifier/_skl.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_taxonomic_classifier.py
+++ b/q2_feature_classifier/_taxonomic_classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/custom.py
+++ b/q2_feature_classifier/custom.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/plugin_setup.py
+++ b/q2_feature_classifier/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/tests/__init__.py
+++ b/q2_feature_classifier/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/tests/test_classifier.py
+++ b/q2_feature_classifier/tests/test_classifier.py
@@ -8,7 +8,6 @@
 
 import json
 import os
-import unittest.mock
 
 from qiime2.sdk import Artifact
 from q2_types.feature_data import DNAIterator
@@ -243,32 +242,3 @@ class ClassifierTests(FeatureClassifierTestPluginBase):
     def test_autotune_reads_per_batch_more_jobs_than_reads(self):
         self.assertEqual(
             _autotune_reads_per_batch(self.seq_path, n_jobs=1105), 1)
-
-    def test_classify_sklearn(self):
-        '''
-        with self.assertRaisesRegex(
-                                    MemoryError, "run out of available memory"
-                                    ):
-            classify_sklearn(self.seq_path, self.classifier,
-                             reads_per_batch=0, n_jobs=5,
-                             read_orientation='auto')
-                             '''
-        with unittest.mock.patch('list(zip(*predictions))',
-                                 side_effect=MemoryError):
-            self.assertRaisesRegex("run out of available memory")
-
-            '''
-            reads: DNAFASTAFormat, classifier: Pipeline,
-                     reads_per_batch: int = 0, n_jobs: int = 1,
-                     pre_dispatch: str = '2*n_jobs', confidence: float = 0.7,
-                     read_orientation: str = 'auto'
-                     ) -> pd.DataFrame:
-            '''
-    '''
-    def test_classify_sklearn_memory_consumption(self):
-        with unittest.mock.patch('list(zip(*predictions))',
-                                 side_effect=MemoryError):
-            with self.assertRaisesRegex(MemoryError,
-                                        "run out of available memory"):
-                # Do Something
-                '''

--- a/q2_feature_classifier/tests/test_classifier.py
+++ b/q2_feature_classifier/tests/test_classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,6 +8,7 @@
 
 import json
 import os
+import unittest.mock
 
 from qiime2.sdk import Artifact
 from q2_types.feature_data import DNAIterator
@@ -242,3 +243,32 @@ class ClassifierTests(FeatureClassifierTestPluginBase):
     def test_autotune_reads_per_batch_more_jobs_than_reads(self):
         self.assertEqual(
             _autotune_reads_per_batch(self.seq_path, n_jobs=1105), 1)
+
+    def test_classify_sklearn(self):
+        '''
+        with self.assertRaisesRegex(
+                                    MemoryError, "run out of available memory"
+                                    ):
+            classify_sklearn(self.seq_path, self.classifier,
+                             reads_per_batch=0, n_jobs=5,
+                             read_orientation='auto')
+                             '''
+        with unittest.mock.patch('list(zip(*predictions))',
+                                 side_effect=MemoryError):
+            self.assertRaisesRegex("run out of available memory")
+
+            '''
+            reads: DNAFASTAFormat, classifier: Pipeline,
+                     reads_per_batch: int = 0, n_jobs: int = 1,
+                     pre_dispatch: str = '2*n_jobs', confidence: float = 0.7,
+                     read_orientation: str = 'auto'
+                     ) -> pd.DataFrame:
+            '''
+    '''
+    def test_classify_sklearn_memory_consumption(self):
+        with unittest.mock.patch('list(zip(*predictions))',
+                                 side_effect=MemoryError):
+            with self.assertRaisesRegex(MemoryError,
+                                        "run out of available memory"):
+                # Do Something
+                '''

--- a/q2_feature_classifier/tests/test_consensus_assignment.py
+++ b/q2_feature_classifier/tests/test_consensus_assignment.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/tests/test_custom.py
+++ b/q2_feature_classifier/tests/test_custom.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/tests/test_cutter.py
+++ b/q2_feature_classifier/tests/test_cutter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_feature_classifier/tests/test_taxonomic_classifier.py
+++ b/q2_feature_classifier/tests/test_taxonomic_classifier.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016-2019, QIIME 2 development team.
+# Copyright (c) 2016-2020, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
Updated copyright headers to reflect current year. There was a commented unit test that utilized a `mock` import, which has nothing to do with this PR. I removed those lines in the second commit. The only impacted files should pertain to the changed copyright headers.