### PR TITLE
improve extract-reads docs

### DIFF
--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -232,47 +232,47 @@ plugin.methods.register_function(
                 'read_orientation': Str % Choices(['both', 'forward',
                                                    'reverse'])},
     outputs=[('reads', FeatureData[Sequence])],
-    name='Extract reads from reference',
-    description='Extract sequencing-like reads from a reference database.',
-    parameter_descriptions={'f_primer': 'forward primer sequence',
-                            'r_primer': 'reverse primer sequence',
-                            'trim_right': 'trim_right nucleotides are removed '
-                                          'from the 3\' end if trim_right is '
-                                          'positive.Applied before trunc_len.',
-                            'trunc_len': 'read is cut to trunc_len if '
-                                         'trunc_len is positive. Applied '
-                                         'after trim_right.',
-                            'trim_left': 'trim_left nucleotides are removed '
-                                         'from the 5\' end if trim_left is '
-                                         'positive. Applied after trim_right '
-                                         'and trunc_len.',
-                            'identity': 'minimum combined primer match '
-                                        'identity threshold.',
-                            'min_length': 'Minimum amplicon length. Shorter '
-                                          'amplicons are discarded. Applied '
-                                          'after trimming and truncation, so '
-                                          'be aware that trimming may impact '
-                                          'sequence retention. Set to zero '
-                                          'to disable min length filtering.',
-                            'max_length': 'Maximum amplicon length. Longer '
-                                          'amplicons are discarded. Applied '
-                                          'before trimming and truncation, '
-                                          'so plan accordingly. Set to zero '
-                                          '(default) to disable max length '
-                                          'filtering.',
-                            'n_jobs': 'Number of seperate processes to run.',
-                            'batch_size': 'Number of sequences to process in '
-                                          'a batch. The `auto` option is '
-                                          'calculated from the number of '
-                                          'sequences and number of jobs '
-                                          'specified.',
-                            'read_orientation': 'Orientation of primers '
-                                                'relative to the sequences: '
-                                                '"forward" searches for '
-                                                'primer hits in the forward '
-                                                'direction, "reverse" '
-                                                'searches the '
-                                                'reverse-complement, and '
-                                                '"both" searches both '
-                                                'directions.'}
+    name='Extract reads from reference sequences.',
+    description='Extract simulated amplicon reads from a reference database. '
+                'Performs in-silico PCR to extract simulated amplicons from '
+                'reference sequences that match the input primer sequences '
+                '(within the mismatch threshold specified by `identity`). '
+                'Both primer sequences must be in the 5\' -> 3\' orientation. '
+                'Sequences that fail to match both primers will be excluded. '
+                'Reads are extracted, trimmed, and filtered in the following '
+                'order: 1. reads are extracted in specified orientation; 2. '
+                'primers are removed; 3. reads longer than `max_length` are '
+                'removed; 4. reads are trimmed with `trim_right`; 5. reads '
+                'are truncated to `trunc_len`; 6. reads are trimmed with '
+                '`trim_left`; 7. reads shorter than `min_length` are removed.',
+    parameter_descriptions={
+        'f_primer': 'forward primer sequence (5\' -> 3\').',
+        'r_primer': 'reverse primer sequence (5\' -> 3\'). Do not use reverse-'
+                    'complemented primer sequence.',
+        'trim_right': 'trim_right nucleotides are removed from the 3\' end if '
+                      'trim_right is positive. Applied before trunc_len and '
+                      'trim_left.',
+        'trunc_len': 'read is cut to trunc_len if trunc_len is positive. '
+                     'Applied after trim_right but before trim_left.',
+        'trim_left': 'trim_left nucleotides are removed from the 5\' end if '
+                     'trim_left is positive. Applied after trim_right and '
+                     'trunc_len.',
+        'identity': 'minimum combined primer match identity threshold.',
+        'min_length': 'Minimum amplicon length. Shorter amplicons are '
+                      'discarded. Applied after trimming and truncation, so '
+                      'be aware that trimming may impact sequence retention. '
+                      'Set to zero to disable min length filtering.',
+        'max_length': 'Maximum amplicon length. Longer amplicons are '
+                      'discarded. Applied before trimming and truncation, '
+                      'so plan accordingly. Set to zero (default) to disable '
+                      'max length filtering.',
+        'n_jobs': 'Number of seperate processes to run.',
+        'batch_size': 'Number of sequences to process in a batch. The `auto` '
+                      'option is calculated from the number of sequences and '
+                      'number of jobs specified.',
+        'read_orientation': 'Orientation of primers relative to the '
+                            'sequences: "forward" searches for primer hits in '
+                            'the forward direction, "reverse" searches the '
+                            'reverse-complement, and "both" searches both '
+                            'directions.'}
 )

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -272,7 +272,7 @@ plugin.methods.register_function(
                       'number of jobs specified.',
         'read_orientation': 'Orientation of primers relative to the '
                             'sequences: "forward" searches for primer hits in '
-                            'the forward direction, "reverse" searches the '
+                            'the forward direction, "reverse" searches '
                             'reverse-complement, and "both" searches both '
                             'directions.'}
 )


### PR DESCRIPTION
fixes #121 

while adding the clarification described in #121 , I decided to tidy up. Full changelog:

* specified 5' -> 3' orientation for `f_primer` and `r_primer` param descriptions.
* re-organized the docs a bit (moved param names down one indented line to condense docs)
* added an extended `description`.