### PR TITLE
vsearch: options incompatible with --search_exact

### DIFF
--- a/q2_feature_classifier/_vsearch.py
+++ b/q2_feature_classifier/_vsearch.py
@@ -50,6 +50,12 @@ def classify_consensus_vsearch(query: DNAFASTAFormat,
            '--threads', str(threads)]
     if search_exact:
         cmd[1] = '--search_exact'
+        # Remove options, and their matching argument, which are not compatible
+        # a --search_exact in recent versions of vsearch (such as 2.15.1).
+        for pop_arg in ['--id', '--maxaccepts', '--maxrejects', '--query_cov']:
+            pop_idx = cmd.index(pop_arg)
+            cmd.pop(pop_idx)
+            cmd.pop(pop_idx)
     if top_hits_only:
         cmd.append('--top_hits_only')
     if output_no_hits:


### PR DESCRIPTION
Good day,

When running the test suite on a system set up with _vsearch_ 2.15.1, the _test_consensus_assignment.py_ fails its test involving _search_exact_ with an error message including the following relevant part:

	Command: vsearch --search_exact /build/q2_feature_classifier/tests/data/se-dna-sequences.fasta --id 0.8 --query_cov 0.8 --strand both --maxaccepts 10 --maxrejects 0 --db /build/q2_feature_classifier/tests/data/se-dna-sequences.fasta --threads 1 --output_no_hits --blast6out /tmp/tmpomuor76d

	----------------------------- Captured stderr call -----------------------------
	Fatal error: Invalid options to command search_exact
	Invalid option(s): --id --maxaccepts --maxrejects --query_cov
	The valid options for the search_exact command are: --alnout --biomout --blast6out --bzip2_decompress --db --dbmask --dbmatched --dbnotmatched --fasta_width --fastapairs --gzip_decompress --hardmask --log --match --matched --maxhits --maxqsize --maxqt --maxseqlength --maxsizeratio --maxsl --mincols --minqt --minseqlength --minsizeratio --minsl --mintsize --mismatch --mothur_shared_out --no_progress --notmatched --notrunclabels --otutabout --output_no_hits --qmask --quiet --relabel --relabel_keep --relabel_md5 --relabel_self --relabel_sha1 --rowlen --samheader --samout --self --sizein --sizeout --strand --threads --top_hits_only --uc --uc_allhits --userfields --userout --xee --xsize

This commit alters the _vsearch_ command issued by _classify_consensus_vsearch_ by removing the options, and their argument, incompatible with _--search_exact_.

---

The issue has been caught initially when integrating the package into Debian and discussed alongside Bug#974839[1].

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=974839#24

Please note that I'm not competent with _vsearch_, so I most likely overlooked other options to set for an optimum usage, but you probably want to at least be aware of the issue.

Have a nice day,  :)