### PR TITLE
ENH: optional use of BLASTDB pre-indexed db input to `blast`

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - joblib
     - scikit-bio {{ scikit_bio }}
     - biom-format {{ biom_format }}
-    - blast >=2.6.0
+    - blast >=2.13.0
     - vsearch
     - qiime2 {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*

--- a/q2_feature_classifier/__init__.py
+++ b/q2_feature_classifier/__init__.py
@@ -12,6 +12,7 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+importlib.import_module('q2_feature_classifier.types')
 importlib.import_module('q2_feature_classifier.classifier')
 importlib.import_module('q2_feature_classifier._cutter')
 importlib.import_module('q2_feature_classifier._blast')

--- a/q2_feature_classifier/_blast.py
+++ b/q2_feature_classifier/_blast.py
@@ -97,13 +97,9 @@ def blast(query: DNAFASTAFormat,
         if len(missing_ids) > 0:
             # we will mirror vsearch behavior and annotate unassigneds as '*'
             # and fill other columns with 0 values (np.nan makes format error).
-            missed = pd.DataFrame(columns=result.columns)
             missed = pd.DataFrame(
                 [{'qseqid': i, 'sseqid': '*'} for i in missing_ids],
                 columns=result.columns).fillna(0)
-            # Do two separate appends to make sure that fillna does not alter
-            # any other contents from the original search results.
-            # result = result.append(missed, ignore_index=True)
             result = pd.concat([result, missed], axis=0)
     return result
 

--- a/q2_feature_classifier/_blast.py
+++ b/q2_feature_classifier/_blast.py
@@ -6,11 +6,14 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import os
+import warnings
 import subprocess
 import pandas as pd
 from q2_types.feature_data import (
     FeatureData, Taxonomy, Sequence, DNAFASTAFormat, DNAIterator, BLAST6,
     BLAST6Format)
+from .types import BLASTDBDirFmtV5, BLASTDB
 from qiime2.plugin import Int, Str, Float, Choices, Range, Bool
 from .plugin_setup import plugin, citations
 from ._consensus_assignment import (
@@ -36,6 +39,7 @@ DEFAULTSTRAND = 'both'
 DEFAULTEVALUE = 0.001
 DEFAULTMINCONSENSUS = 0.51
 DEFAULTOUTPUTNOHITS = True
+DEFAULTNUMTHREADS = 1
 
 
 # NOTE FOR THE FUTURE: should this be called blastn? would it be possible to
@@ -46,23 +50,40 @@ DEFAULTOUTPUTNOHITS = True
 # expose different parameters etc? My feeling is let's call this `blast` for
 # now and then cross that bridge when we come to it.
 def blast(query: DNAFASTAFormat,
-          reference_reads: DNAFASTAFormat,
+          reference_reads: DNAFASTAFormat = None,
+          blastdb: BLASTDBDirFmtV5 = None,
           maxaccepts: int = DEFAULTMAXACCEPTS,
           perc_identity: float = DEFAULTPERCENTID,
           query_cov: float = DEFAULTQUERYCOV,
           strand: str = DEFAULTSTRAND,
           evalue: float = DEFAULTEVALUE,
-          output_no_hits: bool = DEFAULTOUTPUTNOHITS) -> pd.DataFrame:
+          output_no_hits: bool = DEFAULTOUTPUTNOHITS,
+          num_threads: int = DEFAULTNUMTHREADS) -> pd.DataFrame:
+    if reference_reads and blastdb:
+        raise ValueError('Only one reference_reads or blastdb artifact '
+                         'can be provided as input. Choose one and try '
+                         'again.')
     perc_identity = perc_identity * 100
     query_cov = query_cov * 100
     seqs_fp = str(query)
-    ref_fp = str(reference_reads)
     # TODO: generalize to support other blast types?
     output = BLAST6Format()
     cmd = ['blastn', '-query', seqs_fp, '-evalue', str(evalue), '-strand',
-           strand, '-outfmt', '6', '-subject', ref_fp, '-perc_identity',
-           str(perc_identity), '-qcov_hsp_perc', str(query_cov),
+           strand, '-outfmt', '6', '-perc_identity', str(perc_identity),
+           '-qcov_hsp_perc', str(query_cov), '-num_threads', str(num_threads),
            '-max_target_seqs', str(maxaccepts), '-out', str(output)]
+    if reference_reads:
+        cmd.extend(['-subject', str(reference_reads)])
+        if num_threads > 1:
+            warnings.warn('The num_threads parameters is only compatible '
+                          'when using a pre-indexed blastdb. The num_threads '
+                          'is ignored when reference_reads are provided as '
+                          'input.', UserWarning)
+    elif blastdb:
+        cmd.extend(['-db', os.path.join(blastdb.path, blastdb.get_basename())])
+    else:
+        raise ValueError('Either reference_reads or a blastdb must be '
+                         'provided as input.')
     _run_command(cmd)
     # load as dataframe to quickly validate (note: will fail now if empty)
     result = output.view(pd.DataFrame)
@@ -77,18 +98,21 @@ def blast(query: DNAFASTAFormat,
             # we will mirror vsearch behavior and annotate unassigneds as '*'
             # and fill other columns with 0 values (np.nan makes format error).
             missed = pd.DataFrame(columns=result.columns)
-            missed = missed.append(
-                [{'qseqid': i, 'sseqid': '*'} for i in missing_ids]).fillna(0)
+            missed = pd.DataFrame(
+                [{'qseqid': i, 'sseqid': '*'} for i in missing_ids],
+                columns=result.columns).fillna(0)
             # Do two separate appends to make sure that fillna does not alter
             # any other contents from the original search results.
-            result = result.append(missed, ignore_index=True)
+            # result = result.append(missed, ignore_index=True)
+            result = pd.concat([result, missed], axis=0)
     return result
 
 
 def classify_consensus_blast(ctx,
                              query,
-                             reference_reads,
                              reference_taxonomy,
+                             blastdb=None,
+                             reference_reads=None,
                              maxaccepts=DEFAULTMAXACCEPTS,
                              perc_identity=DEFAULTPERCENTID,
                              query_cov=DEFAULTQUERYCOV,
@@ -96,13 +120,15 @@ def classify_consensus_blast(ctx,
                              evalue=DEFAULTEVALUE,
                              output_no_hits=DEFAULTOUTPUTNOHITS,
                              min_consensus=DEFAULTMINCONSENSUS,
-                             unassignable_label=DEFAULTUNASSIGNABLELABEL):
+                             unassignable_label=DEFAULTUNASSIGNABLELABEL,
+                             num_threads=DEFAULTNUMTHREADS):
     search_db = ctx.get_action('feature_classifier', 'blast')
     lca = ctx.get_action('feature_classifier', 'find_consensus_annotation')
-    result, = search_db(query=query, reference_reads=reference_reads,
+    result, = search_db(query=query, blastdb=blastdb,
+                        reference_reads=reference_reads,
                         maxaccepts=maxaccepts, perc_identity=perc_identity,
                         query_cov=query_cov, strand=strand, evalue=evalue,
-                        output_no_hits=output_no_hits)
+                        output_no_hits=output_no_hits, num_threads=num_threads)
     consensus, = lca(search_results=result,
                      reference_taxonomy=reference_taxonomy,
                      min_consensus=min_consensus,
@@ -111,6 +137,15 @@ def classify_consensus_blast(ctx,
     # visualizer generated from these results (using q2-metadata tabulate).
     # Would that be more useful to the user that the QZA?
     return consensus, result
+
+
+def makeblastdb(sequences: DNAFASTAFormat) -> BLASTDBDirFmtV5:
+    database = BLASTDBDirFmtV5()
+    build_cmd = ['makeblastdb', '-blastdb_version', '5', '-dbtype', 'nucl',
+                 '-title', 'blastdb', '-in', str(sequences),
+                 '-out', os.path.join(str(database.path), 'blastdb')]
+    _run_command(build_cmd)
+    return database
 
 
 # Replace this function with QIIME2 API for wrapping commands/binaries,
@@ -128,10 +163,14 @@ def _run_command(cmd, verbose=True):
 
 
 inputs = {'query': FeatureData[Sequence],
+          'blastdb': BLASTDB,
           'reference_reads': FeatureData[Sequence]}
 
 input_descriptions = {'query': 'Query sequences.',
-                      'reference_reads': 'Reference sequences.'}
+                      'blastdb': 'BLAST indexed database. Incompatible with '
+                      'reference_reads.',
+                      'reference_reads': 'Reference sequences. Incompatible '
+                      'with blastdb.'}
 
 classification_output = ('classification', FeatureData[Taxonomy])
 
@@ -144,6 +183,7 @@ parameters = {'evalue': Float,
               'query_cov': Float % Range(0.0, 1.0, inclusive_end=True),
               'strand': Str % Choices(['both', 'plus', 'minus']),
               'output_no_hits': Bool,
+              'num_threads': Int % Range(1, None),
               }
 
 parameter_descriptions = {
@@ -170,11 +210,26 @@ parameter_descriptions = {
                       'unclassified sequences, otherwise you may run into '
                       'errors downstream from missing feature IDs. Set to '
                       'FALSE to mirror default BLAST search.',
+    'num_threads': 'Number of threads (CPUs) to use in the BLAST search.'
 }
 
 blast6_output = ('search_results', FeatureData[BLAST6])
 
 blast6_output_description = {'search_results': 'Top hits for each query.'}
+
+
+plugin.methods.register_function(
+    function=makeblastdb,
+    inputs={'sequences': FeatureData[Sequence]},
+    parameters={},
+    outputs=[('database', BLASTDB)],
+    input_descriptions={'sequences': 'Input reference sequences.'},
+    parameter_descriptions={},
+    output_descriptions={'database': 'Output BLAST database.'},
+    name='Make BLAST database.',
+    description=('Make BLAST database from custom sequence collection.'),
+    citations=[citations['camacho2009blast+']]
+)
 
 
 # Note: name should be changed to blastn if we do NOT generalize this function

--- a/q2_feature_classifier/types/__init__.py
+++ b/q2_feature_classifier/types/__init__.py
@@ -1,0 +1,13 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2023, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from ._format import BLASTDBFileFmtV5, BLASTDBDirFmtV5
+from ._type import BLASTDB
+
+
+__all__ = ['BLASTDBFileFmtV5', 'BLASTDBDirFmtV5', 'BLASTDB']

--- a/q2_feature_classifier/types/_format.py
+++ b/q2_feature_classifier/types/_format.py
@@ -23,8 +23,8 @@ class BLASTDBFileFmtV5(model.BinaryFileFormat):
 
 class BLASTDBDirFmtV5(model.DirectoryFormat):
     # TODO: is there a more robust way to do this/make some files optional?
-    # Some file extensions were introduced with more recent versions of 
-    # blast, but are not actually needed for our purposes. Making these 
+    # Some file extensions were introduced with more recent versions of
+    # blast, but are not actually needed for our purposes. Making these
     # optional would allow more flexibility in blast versions, avoiding
     # possible dependency conflicts.
     # NOTE that the .n?? extensions are also nucleotide database specific.

--- a/q2_feature_classifier/types/_format.py
+++ b/q2_feature_classifier/types/_format.py
@@ -22,6 +22,13 @@ class BLASTDBFileFmtV5(model.BinaryFileFormat):
 
 
 class BLASTDBDirFmtV5(model.DirectoryFormat):
+    # TODO: is there a more robust way to do this/make some files optional?
+    # Some file extensions were introduced with more recent versions of 
+    # blast, but are not actually needed for our purposes. Making these 
+    # optional would allow more flexibility in blast versions, avoiding
+    # possible dependency conflicts.
+    # NOTE that the .n?? extensions are also nucleotide database specific.
+    # should we rather call the type/formats BLASTNucDB*?
     idx1 = model.File(r'.+\.ndb', format=BLASTDBFileFmtV5)
     idx2 = model.File(r'.+\.nhr', format=BLASTDBFileFmtV5)
     idx3 = model.File(r'.+\.nin', format=BLASTDBFileFmtV5)
@@ -29,6 +36,7 @@ class BLASTDBDirFmtV5(model.DirectoryFormat):
     idx5 = model.File(r'.+\.nsq', format=BLASTDBFileFmtV5)
     idx6 = model.File(r'.+\.ntf', format=BLASTDBFileFmtV5)
     idx7 = model.File(r'.+\.nto', format=BLASTDBFileFmtV5)
+    idx8 = model.File(r'.+\.njs', format=BLASTDBFileFmtV5)
 
     # borrowed from q2-types
     def get_basename(self):

--- a/q2_feature_classifier/types/_format.py
+++ b/q2_feature_classifier/types/_format.py
@@ -6,6 +6,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import os
+import itertools
 from qiime2.plugin import model
 from ..plugin_setup import plugin, citations
 
@@ -27,6 +29,22 @@ class BLASTDBDirFmtV5(model.DirectoryFormat):
     idx5 = model.File(r'.+\.nsq', format=BLASTDBFileFmtV5)
     idx6 = model.File(r'.+\.ntf', format=BLASTDBFileFmtV5)
     idx7 = model.File(r'.+\.nto', format=BLASTDBFileFmtV5)
+
+    # borrowed from q2-types
+    def get_basename(self):
+        paths = [str(x.relative_to(self.path)) for x in self.path.iterdir()]
+        prefix = os.path.splitext(_get_prefix(paths))[0]
+        return prefix
+
+
+# SO: https://stackoverflow.com/a/6718380/579416
+def _get_prefix(strings):
+    def all_same(x):
+        return all(x[0] == y for y in x)
+
+    char_tuples = zip(*strings)
+    prefix_tuples = itertools.takewhile(all_same, char_tuples)
+    return ''.join(x[0] for x in prefix_tuples)
 
 
 plugin.register_views(BLASTDBDirFmtV5,

--- a/q2_feature_classifier/types/_format.py
+++ b/q2_feature_classifier/types/_format.py
@@ -36,6 +36,8 @@ class BLASTDBDirFmtV5(model.DirectoryFormat):
     idx5 = model.File(r'.+\.nsq', format=BLASTDBFileFmtV5)
     idx6 = model.File(r'.+\.ntf', format=BLASTDBFileFmtV5)
     idx7 = model.File(r'.+\.nto', format=BLASTDBFileFmtV5)
+    # introducted in blast 2.13.0
+    # https://ncbiinsights.ncbi.nlm.nih.gov/2022/03/29/blast-2-13-0/
     idx8 = model.File(r'.+\.njs', format=BLASTDBFileFmtV5)
 
     # borrowed from q2-types

--- a/q2_feature_classifier/types/_format.py
+++ b/q2_feature_classifier/types/_format.py
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2023, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from qiime2.plugin import model
+from ..plugin_setup import plugin, citations
+
+
+class BLASTDBFileFmtV5(model.BinaryFileFormat):
+    # We do not have a good way to validate the individual blastdb files.
+    # TODO: could wire up `blastdbcheck` to do a deep check when level=max
+    # but this must be done on the directory, not individual files.
+    # For now validation be done at the DirFmt level on file extensions.
+    def _validate_(self, level):
+        pass
+
+
+class BLASTDBDirFmtV5(model.DirectoryFormat):
+    idx1 = model.File(r'.+\.ndb', format=BLASTDBFileFmtV5)
+    idx2 = model.File(r'.+\.nhr', format=BLASTDBFileFmtV5)
+    idx3 = model.File(r'.+\.nin', format=BLASTDBFileFmtV5)
+    idx4 = model.File(r'.+\.not', format=BLASTDBFileFmtV5)
+    idx5 = model.File(r'.+\.nsq', format=BLASTDBFileFmtV5)
+    idx6 = model.File(r'.+\.ntf', format=BLASTDBFileFmtV5)
+    idx7 = model.File(r'.+\.nto', format=BLASTDBFileFmtV5)
+
+
+plugin.register_views(BLASTDBDirFmtV5,
+                      citations=[citations['camacho2009blast+']])

--- a/q2_feature_classifier/types/_type.py
+++ b/q2_feature_classifier/types/_type.py
@@ -1,0 +1,17 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2023, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from qiime2.plugin import SemanticType
+from . import BLASTDBDirFmtV5
+from ..plugin_setup import plugin
+
+
+BLASTDB = SemanticType('BLASTDB')
+
+plugin.register_semantic_types(BLASTDB)
+plugin.register_artifact_class(BLASTDB, BLASTDBDirFmtV5)


### PR DESCRIPTION
fixes #158 

This PR enables optional use of pre-indexed blast databases with blast, instead of using a FASTA as the subject. This is most likely faster overall, and also allows use of parallel jobs.

1. adds `BLASTDB` type (and associated formats)
2. enables optional use of `BLASTDB` as input to `blast`
3. re-introduces `num_threads` as a parameter
4. minor: in the process I also fixed some pandas FutureWarnings that cropped up in the BLAST code.