### PR TITLE
Improve confidence-based taxonomy prediction performance

### DIFF
--- a/q2_feature_classifier/_skl.py
+++ b/q2_feature_classifier/_skl.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 
 from itertools import islice, repeat
-from copy import deepcopy
 
 from joblib import Parallel, delayed
 

--- a/q2_feature_classifier/_skl.py
+++ b/q2_feature_classifier/_skl.py
@@ -20,7 +20,7 @@ class _TaxonNode:
     # labels. It allows one to quickly find class label indices of taxonomy
     # labels that satisfy a given taxonomy hierarchy. For example, given the
     # 'k__Bacteria' taxon, the _TaxonNode.range property will yield all class
-    # label indices where 'd__Bacteria' is a prefix.
+    # label indices where 'k__Bacteria' is a prefix.
 
     name: str
     offset_index: int

--- a/q2_feature_classifier/_skl.py
+++ b/q2_feature_classifier/_skl.py
@@ -75,13 +75,13 @@ def _predict_chunk_with_conf(pipeline, separator, confidence, chunk):
     split_classes = [c.split(separator) for c in pipeline.classes_]
     for seq_id, taxon, class_probs in zip(seq_ids, y, prob_pos):
         taxon = taxon.split(separator)
-        classes = zip(deepcopy(split_classes), class_probs)
+        classes = zip(split_classes, class_probs)
         result = []
-        for level in taxon:
-            classes = [cls for cls in classes if cls[0].pop(0) == level]
-            cum_prob = sum(c[1] for c in classes)
+        for rank, level in enumerate(taxon):
+            cum_prob = sum(cls[1] for cls in classes if cls[0][rank] == level)
             if cum_prob < confidence:
                 break
+            classes = zip(split_classes, class_probs)
             result.append(level)
             result_confidence = cum_prob
         if result:

--- a/q2_feature_classifier/_skl.py
+++ b/q2_feature_classifier/_skl.py
@@ -13,15 +13,17 @@ from typing import Dict, List
 
 from joblib import Parallel, delayed
 
-# The _TaxonNode is used to build a hierarchy from a list of sorted class
-# labels. It allows one to quickly find class label indices of taxonomy labels
-# that satisfy a given taxonomy hierarchy. For example, given the
-# 'k__Bacteria' taxon, the _TaxonNode.range property will yield all class
-# label indices where 'd__Bacteria' is a prefix.
+
 @dataclass
 class _TaxonNode:
+    # The _TaxonNode is used to build a hierarchy from a list of sorted class
+    # labels. It allows one to quickly find class label indices of taxonomy
+    # labels that satisfy a given taxonomy hierarchy. For example, given the
+    # 'k__Bacteria' taxon, the _TaxonNode.range property will yield all class
+    # label indices where 'd__Bacteria' is a prefix.
+
     name: str
-    offset_index: int # The offset index of this taxon in the class list
+    offset_index: int
     children: Dict[str, "_TaxonNode"] = field(
         default_factory=dict,
         repr=False)


### PR DESCRIPTION
This PR significantly improves the efficiency and performance of confidence-based taxonomy prediction by removing the need for `deepcopy`, resulting in a ~750% speed-up to sequences/second measured on our machine. 
