### PR TITLE
BUG: nondeterministic inclusion of sequences in extract-reads

### DIFF
--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -25,7 +25,7 @@ def _seq_to_regex(seq):
     for base in str(seq):
         if base in skbio.DNA.degenerate_chars:
             result.append('[{0}]'.format(
-                ''.join(skbio.DNA.degenerate_map[base])))
+                ''.join(sorted(skbio.DNA.degenerate_map[base]))))
         else:
             result.append(base)
 
@@ -39,7 +39,7 @@ def _primers_to_regex(f_primer, r_primer):
 
 def _local_aln(primer, sequence):
     best_score = None
-    for one_primer in primer.expand_degenerates():
+    for one_primer in sorted([str(s) for s in primer.expand_degenerates()]):
         # `sequence` may contain degenerates. These will usually be N
         # characters, which SSW will score as zero. Although undocumented, SSW
         # will treat other degenerate characters as a mismatch. We acknowledge
@@ -47,7 +47,8 @@ def _local_aln(primer, sequence):
         # may be revisited in the future if there's an aligner that explicitly
         # handles degenerates.
         this_aln = \
-            skbio.alignment.local_pairwise_align_ssw(one_primer, sequence)
+            skbio.alignment.local_pairwise_align_ssw(skbio.DNA(one_primer),
+                                                     sequence)
         score = this_aln[1]
         if best_score is None or score > best_score:
             best_score = score


### PR DESCRIPTION
Discovered by: https://forum.qiime2.org/t/qiime-feature-classifier-extract-reads-successfully-extracts-different-number-of-reads-each-time/32437

The issue seems to be that degenerate bases are a `set`, which means they get a different order between Python sessions:
https://github.com/scikit-bio/scikit-bio/blob/main/skbio/sequence/_dna.py#L188-L198

As a consequence, when a terrible alignment exists, this code:
```python
if best_score is None or score > best_score:
            best_score = score
```
goes with the first alignment found (which is nondeterministic). Since it's a bad alignment, none of the other concrete sequences in the degenerate list can beat it. So, depending on the specific identity of that first alignment, the sequence will be retained or rejected.

Essentially, only terrible alignments will be occasionally included, based on an (un)lucky order of the degenerate map.

We should do something other than this PR to solve the issue, since I don't think we want these bad alignments anyhow. But worst case, this will at least make the bad alignments appear the same way across different runs.

Another option, which seems to work is increasing `identity` which causes the bad alignments to be filtered out (even if they got lucky before).