### PR TITLE
Unmerged pairs handling

### DIFF
--- a/q2_feature_classifier/_taxonomic_classifier.py
+++ b/q2_feature_classifier/_taxonomic_classifier.py
@@ -117,6 +117,7 @@ def _5(data: dict) -> JSONFormat:
         json.dump(data, fh)
     return result
 
+
 @plugin.register_transformer
 def _6(unmerged: UnmergedPairs) -> DNAFASTAFormat:
     output = DNAFASTAFormat()
@@ -129,6 +130,7 @@ def _6(unmerged: UnmergedPairs) -> DNAFASTAFormat:
                 cleaned = re.sub(r'N+', ' ', line.strip().upper())
                 outfile.write(cleaned + '\n')
     return output
+
 
 # Registrations
 plugin.register_semantic_types(TaxonomicClassifier)

--- a/q2_feature_classifier/_taxonomic_classifier.py
+++ b/q2_feature_classifier/_taxonomic_classifier.py
@@ -7,11 +7,14 @@
 # ----------------------------------------------------------------------------
 
 import json
+import re
 import tarfile
 import os
 
 import sklearn
 import joblib
+from q2_dada2 import UnmergedPairs
+from q2_types.feature_data import DNAFASTAFormat
 from sklearn.pipeline import Pipeline
 import qiime2.plugin
 import qiime2.plugin.model as model
@@ -114,6 +117,18 @@ def _5(data: dict) -> JSONFormat:
         json.dump(data, fh)
     return result
 
+@plugin.register_transformer
+def _6(unmerged: UnmergedPairs) -> DNAFASTAFormat:
+    output = DNAFASTAFormat()
+    with unmerged.open() as infile, output.open() as outfile:
+        for line in infile:
+            if line.startswith('>'):
+                outfile.write(line)
+            else:
+                # Remove runs of N and replace with white space
+                cleaned = re.sub(r'N+', ' ', line.strip().upper())
+                outfile.write(cleaned + '\n')
+    return output
 
 # Registrations
 plugin.register_semantic_types(TaxonomicClassifier)

--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -12,7 +12,6 @@ import inspect
 import warnings
 from itertools import chain, islice
 import subprocess
-import re
 
 import pandas as pd
 from qiime2.plugin import (
@@ -32,6 +31,8 @@ from ._skl import fit_pipeline, predict, _specific_fitters
 from ._taxonomic_classifier import TaxonomicClassifier
 from .plugin_setup import plugin, citations
 from q2_dada2 import UnmergedPairs
+
+
 def _load_class(classname):
     err_message = classname + ' is not a recognised class'
     if '.' not in classname:

--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -12,6 +12,7 @@ import inspect
 import warnings
 from itertools import chain, islice
 import subprocess
+import re
 
 import pandas as pd
 from qiime2.plugin import (
@@ -30,8 +31,7 @@ import joblib
 from ._skl import fit_pipeline, predict, _specific_fitters
 from ._taxonomic_classifier import TaxonomicClassifier
 from .plugin_setup import plugin, citations
-
-
+from q2_dada2 import UnmergedPairs
 def _load_class(classname):
     err_message = classname + ' is not a recognised class'
     if '.' not in classname:
@@ -354,7 +354,7 @@ _parameter_descriptions = {
 
 plugin.methods.register_function(
     function=classify_sklearn,
-    inputs={'reads': FeatureData[Sequence],
+    inputs={'reads': (FeatureData[Sequence] | UnmergedPairs),
             'classifier': TaxonomicClassifier},
     parameters=_classify_parameters,
     outputs=[('classification', FeatureData[Taxonomy])],


### PR DESCRIPTION
Adds support for classifying unmerged paired-end reads.
                                                                                   
  ## Changes                                                                       
                                                                                   
  - Added a transformer to convert `UnmergedPairs` to `DNAFASTAFormat`, cleaning sequences by removing runs of `N` characters (runs produced from new dada2 parameter, see [dada2#189](https://github.com/qiime2/q2-dada2/pull/189) )
  - Updated `classify_sklearn` to additionally accept `UnmergedPairs` as input