### PR TITLE
LANG: 2026.4 update

### DIFF
--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -103,8 +103,6 @@ def _match_percent(primer, target):
         elif (primer_c in skbio.DNA.degenerate_chars and
               target_c in skbio.DNA.degenerate_map[primer_c]):
             matches += 1
-        else:
-            continue
     return matches / len(primer)
 
 

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -8,6 +8,7 @@
 
 import skbio
 import os
+import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
 
 from qiime2.plugin import Int, Str, Float, Range, Choices
@@ -37,54 +38,6 @@ def _primers_to_regex(f_primer, r_primer):
                                _seq_to_regex(r_primer.reverse_complement()))
 
 
-def _local_aln(primer, sequence):
-    best_score = None
-    for one_primer in sorted([str(s) for s in primer.expand_degenerates()]):
-        # `sequence` may contain degenerates. These will usually be N
-        # characters, which SSW will score as zero. Although undocumented, SSW
-        # will treat other degenerate characters as a mismatch. We acknowledge
-        # that this approach is a heuristic to finding an optimal alignment and
-        # may be revisited in the future if there's an aligner that explicitly
-        # handles degenerates.
-        this_aln = \
-            skbio.alignment.local_pairwise_align_ssw(skbio.DNA(one_primer),
-                                                     sequence)
-        score = this_aln[1]
-        if best_score is None or score > best_score:
-            best_score = score
-            best_aln = this_aln
-    return best_aln
-
-
-def _semisemiglobal(primer, sequence, reverse=False):
-    if reverse:
-        primer = primer.reverse_complement()
-
-    # locally align the primer
-    (aln_prim, aln_seq), score, (prim_pos, seq_pos) = \
-        _local_aln(primer, sequence)
-    amplicon_pos = seq_pos[1]+len(primer)-prim_pos[1]
-
-    # naively extend the alignment to be semi-global
-    bits = [primer[:prim_pos[0]], aln_prim, primer[prim_pos[1]+1:]]
-    aln_prim = ''.join(map(str, bits))
-    bits = ['-'*(prim_pos[0]-seq_pos[0]),
-            sequence[max(seq_pos[0]-prim_pos[0], 0):seq_pos[0]],
-            aln_seq,
-            sequence[seq_pos[1]+1:amplicon_pos],
-            '-'*(amplicon_pos-len(sequence))]
-    aln_seq = ''.join(map(str, bits))
-
-    # count the matches
-    matches = sum(s in skbio.DNA.degenerate_map.get(p, {p})
-                  for p, s in zip(aln_prim, aln_seq))
-
-    if reverse:
-        amplicon_pos = max(seq_pos[0]-prim_pos[0], 0)
-
-    return amplicon_pos, matches, len(aln_prim)
-
-
 def _exact_match(seq, f_primer, r_primer):
     try:
         regex = _primers_to_regex(f_primer, r_primer)
@@ -95,12 +48,100 @@ def _exact_match(seq, f_primer, r_primer):
         return None
 
 
+def _create_asymmetric_primer_substitution_matrix(match=2, mismatch=-3):
+    """ Create an asymmetric substitution matrix for matching degenerate
+        primers to target sequences
+
+        This is asymmetic such that degenerate characters in primers will
+        score as matches when the target sequences contains a relevant
+        character. Degenerate characters in target sequences however always
+        score as a mismatch.
+
+        This is designed on the assumption that primers contain degenerate
+        characters because they represent a pool of sequences that will
+        actually be present in a PCR reaction, but degenerate characters in
+        target sequences represent error or uncertainty.
+
+        This is intended for use with `skbio.alignment.pair_align`, and the
+        primer should be passed as the first sequence and the target as the
+        second sequence.
+    """
+    definite_chars = sorted(skbio.DNA.definite_chars)
+    degenerate_chars = sorted(skbio.DNA.degenerate_chars)
+    chars = definite_chars + degenerate_chars
+
+    sm = np.zeros((len(chars), len(chars)))
+
+    for row, c1 in enumerate(chars):
+        for col, c2 in enumerate(chars):
+            if c1 in definite_chars:
+                if c2 in definite_chars:
+                    if c1 == c2:
+                        sm[(row, col)] = match
+                    else:
+                        sm[(row, col)] = mismatch
+                else:  # degenerate char in query sequence is always a mismatch
+                    sm[(row, col)] = mismatch
+            else:  # primer character is degenerate
+                if c2 in skbio.DNA.degenerate_map[c1]:
+                    sm[(row, col)] = match
+                else:
+                    sm[(row, col)] = mismatch
+    return skbio.SubstitutionMatrix(chars, sm)
+
+
+def _match_percent(primer, target):
+    """ Compute percent of matching positions in alignments, accounting for
+        primer degeneracies
+    """
+    matches = 0
+    for primer_c, target_c in zip(str(primer), str(target)):
+        if target_c in skbio.DNA.degenerate_chars:
+            continue
+        if primer_c == target_c:
+            matches += 1
+        elif (primer_c in skbio.DNA.degenerate_chars and
+              target_c in skbio.DNA.degenerate_map[primer_c]):
+            matches += 1
+        else:
+            continue
+    return matches / len(primer)
+
+
+def _align_primer(primer, target, substitution_matrix, reverse=False):
+    if reverse:
+        primer = primer.reverse_complement()
+
+    # perform pairwise semi-global alignment, such that gaps on the
+    # ends of primer aren't scored but gaps on the ends of target are
+    # scored.
+    # degenerate characters in primer match the characters they represent,
+    # but degenerate characters in target are always considered
+    # mismatches
+    aln = skbio.alignment.pair_align_nucl(
+        primer, target, mode='global', sub_score=substitution_matrix,
+        free_ends=[True, True, False, False], trim_ends=True)
+    msa = skbio.TabularMSA.from_path_seqs(aln.paths[0], (primer, target))
+    match_percent = _match_percent(msa[0], msa[1])
+
+    if reverse:
+        amplicon_pos = aln.paths[0].starts[1]
+    else:
+        amplicon_pos = aln.paths[0].stops[1]
+
+    return amplicon_pos, match_percent
+
+
 def _approx_match(seq, f_primer, r_primer, identity):
-    beg, b_matches, b_length = _semisemiglobal(f_primer, seq)
-    end, e_matches, e_length = _semisemiglobal(r_primer, seq, reverse=True)
-    if (b_matches + e_matches) / (b_length + e_length) >= identity:
-        return seq[beg:end]
-    return None
+    substitution_matrix = _create_asymmetric_primer_substitution_matrix()
+    amp_start, f_match_percent = \
+        _align_primer(f_primer, seq, substitution_matrix)
+    amp_end, r_match_percent = \
+        _align_primer(r_primer, seq, substitution_matrix, reverse=True)
+    if f_match_percent >= identity and r_match_percent >= identity:
+        return seq[amp_start:amp_end]
+    else:
+        return None
 
 
 def _gen_reads(sequence, f_primer, r_primer, trim_right, trunc_len, trim_left,

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -179,7 +179,7 @@ def _gen_reads(sequence, f_primer, r_primer, trim_right, trunc_len, trim_left,
 def extract_reads(sequences: DNASequencesDirectoryFormat, f_primer: str,
                   r_primer: str, trim_right: int = 0,
                   trunc_len: int = 0, trim_left: int = 0,
-                  identity: float = 0.8, min_length: int = 50,
+                  identity: float = 0.7, min_length: int = 50,
                   max_length: int = 0, n_jobs: int = 1,
                   batch_size: int = 'auto', read_orientation: str = 'both') \
                   -> DNAFASTAFormat:

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -91,7 +91,7 @@ def _create_asymmetric_primer_substitution_matrix(match=2, mismatch=-3):
 
 
 def _match_percent(primer, target):
-    """ Compute percent of matching positions in alignments, accounting for
+    """ Compute proportion of matching positions in alignments, accounting for
         primer degeneracies
     """
     matches = 0

--- a/q2_feature_classifier/_cutter.py
+++ b/q2_feature_classifier/_cutter.py
@@ -50,7 +50,7 @@ def _exact_match(seq, f_primer, r_primer):
 
 def _create_asymmetric_primer_substitution_matrix(match=2, mismatch=-3):
     """ Create an asymmetric substitution matrix for matching degenerate
-        primers to target sequences
+        primers to target sequences.
 
         This is asymmetic such that degenerate characters in primers will
         score as matches when the target sequences contains a relevant
@@ -64,7 +64,9 @@ def _create_asymmetric_primer_substitution_matrix(match=2, mismatch=-3):
 
         This is intended for use with `skbio.alignment.pair_align`, and the
         primer should be passed as the first sequence and the target as the
-        second sequence.
+        second sequence. This is because primers are represented by the rows
+        and the target is represented by columns in the resulting
+        skbio.SubstitutionMatrix.
     """
     definite_chars = sorted(skbio.DNA.definite_chars)
     degenerate_chars = sorted(skbio.DNA.degenerate_chars)
@@ -80,7 +82,7 @@ def _create_asymmetric_primer_substitution_matrix(match=2, mismatch=-3):
                         sm[(row, col)] = match
                     else:
                         sm[(row, col)] = mismatch
-                else:  # degenerate char in query sequence is always a mismatch
+                else:  # degenerate char in target sequence always mismatches
                     sm[(row, col)] = mismatch
             else:  # primer character is degenerate
                 if c2 in skbio.DNA.degenerate_map[c1]:
@@ -92,7 +94,12 @@ def _create_asymmetric_primer_substitution_matrix(match=2, mismatch=-3):
 
 def _match_percent(primer, target):
     """ Compute proportion of matching positions in alignments, accounting for
-        primer degeneracies
+        primer degeneracies.
+
+        Parameters
+        ----------
+        primer : skbio.DNA
+        target : skbio.DNA
     """
     matches = 0
     for primer_c, target_c in zip(str(primer), str(target)):
@@ -110,12 +117,28 @@ def _align_primer(primer, target, substitution_matrix, reverse=False):
     if reverse:
         primer = primer.reverse_complement()
 
-    # perform pairwise semi-global alignment, such that gaps on the
-    # ends of primer aren't scored but gaps on the ends of target are
-    # scored.
+    # perform pairwise semi-global alignment such that gaps on the
+    # ends of primer are free from penalization but gaps on the ends of target
+    # are penalized. for example:
+
+    # gaps on the ends of the primer, as in the following, are free:
+    # --AAAA----------
+    # CCAAAAGGGGCCCCTT
+    # or
+    # ----------CCCC--
+    # CCAAAAGGGGCCCCTT
+
+    # gaps on the end of the target, as in the following, incur the penalty:
+    # AAAA------
+    # --AAGGGGCC
+    # or
+    # ------CCCC
+    # AAGGGGCC--
+
     # degenerate characters in primer match the characters they represent,
     # but degenerate characters in target are always considered
     # mismatches
+
     aln = skbio.alignment.pair_align_nucl(
         primer, target, mode='global', sub_score=substitution_matrix,
         free_ends=[True, True, False, False], trim_ends=True)
@@ -182,7 +205,8 @@ def extract_reads(sequences: DNASequencesDirectoryFormat, f_primer: str,
                   batch_size: int = 'auto', read_orientation: str = 'both') \
                   -> DNAFASTAFormat:
     """Extract the read selected by a primer or primer pair. Only sequences
-    which match the primers at greater than the specified identity are returned
+    which match the primers at greater than the specified identity are
+    returned. Note that the primers are *not* included in the extracted reads.
 
     Parameters
     ----------

--- a/q2_feature_classifier/tests/test_cutter.py
+++ b/q2_feature_classifier/tests/test_cutter.py
@@ -161,7 +161,12 @@ class CutterTests(FeatureClassifierTestPluginBase):
 
 
 class TestCreateAsymmetricPrimerSubstitutionMatrix(
-        FeatureClassifierTestPluginBase):
+        FeatureClassifierTestPluginBase
+):
+    @classmethod
+    def setUpClass(cls):
+        cls.chars = sorted(skbio.DNA.definite_chars) + \
+            sorted(skbio.DNA.degenerate_chars)
 
     def test_returns_substitution_matrix(self):
         sm = _create_asymmetric_primer_substitution_matrix()
@@ -171,8 +176,8 @@ class TestCreateAsymmetricPrimerSubstitutionMatrix(
         sm_default = _create_asymmetric_primer_substitution_matrix()
         sm_custom = _create_asymmetric_primer_substitution_matrix(
             match=5, mismatch=-1)
-        self.assertIsInstance(sm_custom, skbio.SubstitutionMatrix)
-        self.assertFalse(np.array_equal(sm_default.scores, sm_custom.scores))
+        self.assertEqual({2, -3}, set(np.unique(sm_default.scores)))
+        self.assertEqual({5, -1}, set(np.unique(sm_custom.scores)))
 
     def test_matrix_covers_all_dna_chars(self):
         sm = _create_asymmetric_primer_substitution_matrix()
@@ -185,9 +190,7 @@ class TestCreateAsymmetricPrimerSubstitutionMatrix(
         # and 'mismatch' when target is C or G
         sm = _create_asymmetric_primer_substitution_matrix(
             match=2, mismatch=-3)
-        chars = sorted(skbio.DNA.definite_chars) + sorted(
-            skbio.DNA.degenerate_chars)
-        idx = {c: i for i, c in enumerate(chars)}
+        idx = {c: i for i, c in enumerate(self.chars)}
         self.assertEqual(sm.scores[idx['W'], idx['A']], 2)
         self.assertEqual(sm.scores[idx['W'], idx['T']], 2)
         self.assertEqual(sm.scores[idx['W'], idx['C']], -3)
@@ -195,21 +198,18 @@ class TestCreateAsymmetricPrimerSubstitutionMatrix(
 
     def test_definite_primer_vs_degenerate_target_is_always_mismatch(self):
         # A degenerate character in the target is always a mismatch regardless
-        # of which definite base the primer has
+        # of which base the primer has
         sm = _create_asymmetric_primer_substitution_matrix(
             match=2, mismatch=-3)
-        chars = sorted(skbio.DNA.definite_chars) + sorted(
-            skbio.DNA.degenerate_chars)
-        idx = {c: i for i, c in enumerate(chars)}
+        idx = {c: i for i, c in enumerate(self.chars)}
         self.assertEqual(sm.scores[idx['A'], idx['W']], -3)
         self.assertEqual(sm.scores[idx['A'], idx['N']], -3)
+        self.assertEqual(sm.scores[idx['W'], idx['N']], -3)
 
     def test_definite_primer_vs_definite_target_match_and_mismatch(self):
         sm = _create_asymmetric_primer_substitution_matrix(
             match=2, mismatch=-3)
-        chars = sorted(skbio.DNA.definite_chars) + sorted(
-            skbio.DNA.degenerate_chars)
-        idx = {c: i for i, c in enumerate(chars)}
+        idx = {c: i for i, c in enumerate(self.chars)}
         self.assertEqual(sm.scores[idx['A'], idx['A']], 2)
         self.assertEqual(sm.scores[idx['A'], idx['C']], -3)
 
@@ -312,13 +312,13 @@ class TestApproxMatch(FeatureClassifierTestPluginBase):
         seq = skbio.DNA('AAAAGGGGCCCC')
         amplicon = _approx_match(seq, skbio.DNA('AAAA'),
                                  skbio.DNA('GGGG'), identity=0.9)
-        self.assertIsNotNone(amplicon)
         self.assertEqual(str(amplicon), 'GGGG')
 
     def test_f_primer_below_identity_returns_none(self):
-        # TTTT does not match the AAAA region of seq → match_percent = 0.0
+        # TTAA does not match the AAAA region of seq at 0.7 identity
+        # (has 0.5 identity)
         seq = skbio.DNA('AAAAGGGGCCCC')
-        amplicon = _approx_match(seq, skbio.DNA('TTTT'),
+        amplicon = _approx_match(seq, skbio.DNA('TTAA'),
                                  skbio.DNA('GGGG'), identity=0.7)
         self.assertIsNone(amplicon)
 

--- a/q2_feature_classifier/tests/test_cutter.py
+++ b/q2_feature_classifier/tests/test_cutter.py
@@ -6,12 +6,19 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import numpy as np
 import skbio
 
 from qiime2.sdk import Artifact
 from qiime2.plugins.feature_classifier.actions import extract_reads
 from q2_types.feature_data import DNAFASTAFormat
 
+from q2_feature_classifier._cutter import (
+    _create_asymmetric_primer_substitution_matrix,
+    _match_percent,
+    _align_primer,
+    _approx_match,
+)
 from . import FeatureClassifierTestPluginBase
 
 
@@ -151,3 +158,194 @@ class CutterTests(FeatureClassifierTestPluginBase):
             extract_reads(
                 self.sequences, f_primer=self.f_primer, r_primer=self.r_primer,
                 trunc_len=1)
+
+
+class TestCreateAsymmetricPrimerSubstitutionMatrix(
+        FeatureClassifierTestPluginBase):
+
+    def test_returns_substitution_matrix(self):
+        sm = _create_asymmetric_primer_substitution_matrix()
+        self.assertIsInstance(sm, skbio.SubstitutionMatrix)
+
+    def test_custom_match_mismatch_values_produce_different_matrix(self):
+        sm_default = _create_asymmetric_primer_substitution_matrix()
+        sm_custom = _create_asymmetric_primer_substitution_matrix(
+            match=5, mismatch=-1)
+        self.assertIsInstance(sm_custom, skbio.SubstitutionMatrix)
+        self.assertFalse(np.array_equal(sm_default.scores, sm_custom.scores))
+
+    def test_matrix_covers_all_dna_chars(self):
+        sm = _create_asymmetric_primer_substitution_matrix()
+        expected_n = (len(skbio.DNA.definite_chars)
+                      + len(skbio.DNA.degenerate_chars))
+        self.assertEqual(sm.scores.shape, (expected_n, expected_n))
+
+    def test_degenerate_primer_matches_represented_definite_target(self):
+        # W represents {A, T}; should score 'match' when target is A or T
+        # and 'mismatch' when target is C or G
+        sm = _create_asymmetric_primer_substitution_matrix(
+            match=2, mismatch=-3)
+        chars = sorted(skbio.DNA.definite_chars) + sorted(
+            skbio.DNA.degenerate_chars)
+        idx = {c: i for i, c in enumerate(chars)}
+        self.assertEqual(sm.scores[idx['W'], idx['A']], 2)
+        self.assertEqual(sm.scores[idx['W'], idx['T']], 2)
+        self.assertEqual(sm.scores[idx['W'], idx['C']], -3)
+        self.assertEqual(sm.scores[idx['W'], idx['G']], -3)
+
+    def test_definite_primer_vs_degenerate_target_is_always_mismatch(self):
+        # A degenerate character in the target is always a mismatch regardless
+        # of which definite base the primer has
+        sm = _create_asymmetric_primer_substitution_matrix(
+            match=2, mismatch=-3)
+        chars = sorted(skbio.DNA.definite_chars) + sorted(
+            skbio.DNA.degenerate_chars)
+        idx = {c: i for i, c in enumerate(chars)}
+        self.assertEqual(sm.scores[idx['A'], idx['W']], -3)
+        self.assertEqual(sm.scores[idx['A'], idx['N']], -3)
+
+    def test_definite_primer_vs_definite_target_match_and_mismatch(self):
+        sm = _create_asymmetric_primer_substitution_matrix(
+            match=2, mismatch=-3)
+        chars = sorted(skbio.DNA.definite_chars) + sorted(
+            skbio.DNA.degenerate_chars)
+        idx = {c: i for i, c in enumerate(chars)}
+        self.assertEqual(sm.scores[idx['A'], idx['A']], 2)
+        self.assertEqual(sm.scores[idx['A'], idx['C']], -3)
+
+
+class TestMatchPercent(FeatureClassifierTestPluginBase):
+
+    def test_perfect_match(self):
+        result = _match_percent(skbio.DNA('ACGT'), skbio.DNA('ACGT'))
+        self.assertEqual(result, 1.0)
+
+    def test_no_match(self):
+        result = _match_percent(skbio.DNA('AAAA'), skbio.DNA('CCCC'))
+        self.assertEqual(result, 0.0)
+
+    def test_partial_match(self):
+        # 3 of 4 positions match
+        result = _match_percent(skbio.DNA('ACGT'), skbio.DNA('ACGG'))
+        self.assertAlmostEqual(result, 0.75)
+
+    def test_degenerate_primer_char_matches_represented_target(self):
+        # W = {A, T}; counts as a match when target is A or T
+        self.assertEqual(_match_percent(skbio.DNA('W'), skbio.DNA('A')), 1.0)
+        self.assertEqual(_match_percent(skbio.DNA('W'), skbio.DNA('T')), 1.0)
+
+    def test_degenerate_primer_char_no_match(self):
+        # W = {A, T}; does not match C or G
+        self.assertEqual(_match_percent(skbio.DNA('W'), skbio.DNA('C')), 0.0)
+        self.assertEqual(_match_percent(skbio.DNA('W'), skbio.DNA('G')), 0.0)
+
+    def test_n_in_primer_matches_any_definite_target(self):
+        # N represents all bases
+        for base in 'ACGT':
+            self.assertEqual(
+                _match_percent(skbio.DNA('N'), skbio.DNA(base)), 1.0)
+
+    def test_degenerate_target_char_skipped_reduces_score(self):
+        # Degenerate char in TARGET is skipped (not counted as a match),
+        # but the denominator is still len(primer), reducing the score.
+        # ACGT vs ACNT: N at position 2 is skipped → 3 matches out of 4
+        result = _match_percent(skbio.DNA('ACGT'), skbio.DNA('ACNT'))
+        self.assertAlmostEqual(result, 0.75)
+
+
+class TestAlignPrimer(FeatureClassifierTestPluginBase):
+
+    def setUp(self):
+        super().setUp()
+        self.sm = _create_asymmetric_primer_substitution_matrix()
+
+    def test_perfect_forward_match_percent(self):
+        primer = skbio.DNA('AAAA')
+        target = skbio.DNA('GGGGAAAAGGGG')
+        _, match_pct = _align_primer(primer, target, self.sm, reverse=False)
+        self.assertAlmostEqual(match_pct, 1.0)
+
+    def test_perfect_reverse_match_percent(self):
+        # rc('TTTT') = AAAA, which matches the AAAA region perfectly
+        primer = skbio.DNA('TTTT')
+        target = skbio.DNA('GGGGAAAAGGGG')
+        _, match_pct = _align_primer(primer, target, self.sm, reverse=True)
+        self.assertAlmostEqual(match_pct, 1.0)
+
+    def test_partial_forward_match_percent(self):
+        # AAAC aligns to AAAA in target — 3 of 4 positions match
+        primer = skbio.DNA('AAAC')
+        target = skbio.DNA('GGGGAAAAGGGG')
+        _, match_pct = _align_primer(primer, target, self.sm, reverse=False)
+        self.assertAlmostEqual(match_pct, 0.75)
+
+    def test_forward_amplicon_pos_is_after_primer(self):
+        # Forward mode returns a position such that target[pos:] is the content
+        # after the primer
+        primer = skbio.DNA('AAAA')
+        target = skbio.DNA('AAAAGGGG')
+        fwd_pos, _ = _align_primer(primer, target, self.sm, reverse=False)
+        self.assertEqual(str(target[fwd_pos:]), 'GGGG')
+
+    def test_reverse_amplicon_pos_is_before_primer(self):
+        # Reverse mode: rc('GGGG') = CCCC; CCCC matches the end of target
+        # The returned position should be such that target[:pos] is the
+        # amplicon
+        primer = skbio.DNA('GGGG')
+        target = skbio.DNA('AAAACCCC')
+        rev_pos, _ = _align_primer(primer, target, self.sm, reverse=True)
+        self.assertEqual(str(target[:rev_pos]), 'AAAA')
+
+    def test_forward_and_reverse_return_different_positions(self):
+        primer = skbio.DNA('AAAA')
+        target = skbio.DNA('CCCCAAAAGGGG')
+        fwd_pos, _ = _align_primer(primer, target, self.sm, reverse=False)
+        rev_pos, _ = _align_primer(primer, target, self.sm, reverse=True)
+        self.assertNotEqual(fwd_pos, rev_pos)
+
+
+class TestApproxMatch(FeatureClassifierTestPluginBase):
+
+    def test_both_primers_match_returns_correct_amplicon(self):
+        # f_primer AAAA at start; rc(r_primer) = CCCC at end
+        # expected amplicon = GGGG
+        seq = skbio.DNA('AAAAGGGGCCCC')
+        amplicon = _approx_match(seq, skbio.DNA('AAAA'),
+                                 skbio.DNA('GGGG'), identity=0.9)
+        self.assertIsNotNone(amplicon)
+        self.assertEqual(str(amplicon), 'GGGG')
+
+    def test_f_primer_below_identity_returns_none(self):
+        # TTTT does not match the AAAA region of seq → match_percent = 0.0
+        seq = skbio.DNA('AAAAGGGGCCCC')
+        amplicon = _approx_match(seq, skbio.DNA('TTTT'),
+                                 skbio.DNA('GGGG'), identity=0.7)
+        self.assertIsNone(amplicon)
+
+    def test_r_primer_below_identity_returns_none(self):
+        # rc('AAAA') = TTTT, which does not match the CCCC end → 0.0
+        seq = skbio.DNA('AAAAGGGGCCCC')
+        amplicon = _approx_match(seq, skbio.DNA('AAAA'),
+                                 skbio.DNA('AAAA'), identity=0.7)
+        self.assertIsNone(amplicon)
+
+    def test_identity_checked_per_primer_not_combined(self):
+        # f_primer AAAA matches AAAA perfectly (1.0).
+        # r_primer TGGT → rc = ACCA; best match against CCCC end is 2/4 = 0.5.
+        # Per-primer check at identity=0.7: 0.5 < 0.7 → None.
+        # Under a combined-identity scheme: (1.0 + 0.5) / 2 = 0.75 ≥ 0.7
+        # would have passed, so this test distinguishes the two behaviours.
+        seq = skbio.DNA('AAAAGGGGCCCC')
+        amplicon = _approx_match(seq, skbio.DNA('AAAA'),
+                                 skbio.DNA('TGGT'), identity=0.7)
+        self.assertIsNone(amplicon)
+
+    def test_identity_one_requires_perfect_match(self):
+        seq = skbio.DNA('AAAAGGGGCCCC')
+        self.assertIsNotNone(
+            _approx_match(seq, skbio.DNA('AAAA'), skbio.DNA('GGGG'),
+                          identity=1.0))
+        # One mismatch in f_primer → should fail at identity=1.0
+        self.assertIsNone(
+            _approx_match(seq, skbio.DNA('AAAC'), skbio.DNA('GGGG'),
+                          identity=1.0))


### PR DESCRIPTION
This replaces #217. The following is copied from that discussion:

> Note that the unit tests are passing for my updates to the aligner, but I'm still working on some real-world testing of these changes. I'll add some notes here as I go. As we discussed, we're still a little way off from merging these PRs across the distros - I should be done by the time that's all ready to go.
> 
> Update: I did some experimenting and documented the updates - all of that is [here](https://gist.github.com/gregcaporaso/1f00f93f967331a764a6940e5b464472) for now. I think the changes to _cutter.py are good to go, but I'm going to share with a few folks and will circle back if that changes.
>
> Another update: I did some experimenting with the identity parameter today, and I do think we should drop it to 0.70 as I think with the new code we're not extracting some reads that do have reasonable alignments. I'm seeing some reads that are no longer extracted though that I can't currently explain (they forward and reverse alignments result in sequences that exceed my identity threshold), so we should add some additional unit tests of the new functionality here before these changes are merged to make sure that it's all working as expected. A possible reason for this is how the output of my new function interacts with the trimming/truncating/length parameters (e.g., am I dropping the primers from the extracted reads too soon).

Still to-do:
- [x] update default value for identity parameter
- [x] add new unit tests as described above