### PR TITLE
add support for linkedsequence in classify-sklearn

### DIFF
--- a/q2_feature_classifier/classifier.py
+++ b/q2_feature_classifier/classifier.py
@@ -18,7 +18,8 @@ from qiime2.plugin import (
     Int, Str, Float, Bool, Choices, Range, Threads, get_available_cores
 )
 from q2_types.feature_data import (
-    FeatureData, Taxonomy, Sequence, DNAIterator, DNAFASTAFormat)
+    FeatureData, Taxonomy, Sequence, DNAIterator, LinkedSequence, LinkedDNA,
+    FASTAFormat)
 from q2_types.feature_table import FeatureTable, RelativeFrequency
 from sklearn.pipeline import Pipeline
 import sklearn
@@ -204,7 +205,7 @@ def _autotune_reads_per_batch(reads, n_jobs):
         return 20000
 
 
-def classify_sklearn(reads: DNAFASTAFormat, classifier: Pipeline,
+def classify_sklearn(reads: FASTAFormat, classifier: Pipeline,
                      reads_per_batch: int = 'auto', n_jobs: int = 1,
                      pre_dispatch: str = '2*n_jobs', confidence: float = 0.7,
                      read_orientation: str = 'auto'
@@ -220,7 +221,7 @@ def classify_sklearn(reads: DNAFASTAFormat, classifier: Pipeline,
 
         # transform reads to DNAIterator
         reads_iter = DNAIterator(
-            skbio.read(str(reads), format='fasta', constructor=skbio.DNA))
+            skbio.read(str(reads), format='fasta', constructor=LinkedDNA))
         reads_iter = _autodetect_orientation(
             reads_iter, classifier, read_orientation=read_orientation)
 
@@ -234,7 +235,7 @@ def classify_sklearn(reads: DNAFASTAFormat, classifier: Pipeline,
                 confidence=confidence
             )
             reads_reverse_iter = DNAIterator(
-                skbio.read(str(reads), format='fasta', constructor=skbio.DNA))
+                skbio.read(str(reads), format='fasta', constructor=LinkedDNA))
             reverse_comp_predict = predict(
                 (r.reverse_complement() for r in reads_reverse_iter),
                 classifier,
@@ -354,7 +355,7 @@ _parameter_descriptions = {
 
 plugin.methods.register_function(
     function=classify_sklearn,
-    inputs={'reads': FeatureData[Sequence],
+    inputs={'reads': FeatureData[Sequence | LinkedSequence],
             'classifier': TaxonomicClassifier},
     parameters=_classify_parameters,
     outputs=[('classification', FeatureData[Taxonomy])],

--- a/q2_feature_classifier/tests/test_classifier.py
+++ b/q2_feature_classifier/tests/test_classifier.py
@@ -208,6 +208,21 @@ class ClassifierTests(FeatureClassifierTestPluginBase):
         for taxon in fc:
             self.assertEqual(fc[taxon], cc[taxon])
 
+    def test_classify_linkedseq(self):
+        # confirm that classification works with sequences containing gaps.
+        # no need to test contents, just make sure the action does not choke.
+        classify = feature_classifier.methods.classify_sklearn
+        seq_data = pd.Series(
+            ['ATTGAACGCTGGCGGCACGCCTAACACATGCAAGTCGAACGGCAGCGGGGGAAAGC'
+             'TTGCTTTCCTGCCGGCGAGTGGCGGACGGGTGAGTAATGCGTAGGAATTTGCCATT'
+             'AAGAGGGGGA CAACTCGGGGAAACTCGAGCTAATACCA',
+             'ATTGAACGCTG CGGCACGCCTAACACATGCAAGTCGAACGGCAGCGGGGGAAAGC'
+             'TTGCTT CCTGCCGGCGAGTGG GGACGGGTGAGTAATGCGTAGGAAT TGCCATT'
+             'AAGAGGGGGA CAACTCGGGGAAACTCGAGCTAATACCA'], index=['s1', 's2'])
+        reads = Artifact.import_data('FeatureData[LinkedSequence]', seq_data)
+        result = classify(reads, self.classifier,
+                          read_orientation='auto')
+
     def test_unassigned_taxa(self):
         # classifications that don't meet the threshold should be "Unassigned"
         classify = feature_classifier.methods.classify_sklearn

--- a/q2_feature_classifier/tests/test_classifier.py
+++ b/q2_feature_classifier/tests/test_classifier.py
@@ -220,8 +220,7 @@ class ClassifierTests(FeatureClassifierTestPluginBase):
              'TTGCTT CCTGCCGGCGAGTGG GGACGGGTGAGTAATGCGTAGGAAT TGCCATT'
              'AAGAGGGGGA CAACTCGGGGAAACTCGAGCTAATACCA'], index=['s1', 's2'])
         reads = Artifact.import_data('FeatureData[LinkedSequence]', seq_data)
-        result = classify(reads, self.classifier,
-                          read_orientation='auto')
+        classify(reads, self.classifier, read_orientation='auto')
 
     def test_unassigned_taxa(self):
         # classifications that don't meet the threshold should be "Unassigned"


### PR DESCRIPTION
# Description
Adds support for `FeatureData[LinkedSequence]` as input to `classify-sklearn` (i.e., [DNA] sequences containing gaps of unknown length, e.g., from paired-end Illumina reads that fail to merge) 

Depends on https://github.com/qiime2/q2-types/pull/397

Tested on local LinkedSequence data (unmerged ITS sequence data), confirm that results correspond to classifications obtained from only single-end reads 🥗 

(note for others who try this on real data: results should be reasonably similar but are not expected to match perfectly to single-end read classifications, due to the difference in effective length as well as paired-end read loss during denoising due to reasons other than merging issues)

# AI Disclosure

- [X] NO AI USED.
- [ ] AI USED.

